### PR TITLE
feat: Windows support

### DIFF
--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -5,7 +5,12 @@ implementation written in Node.js).
 
 from ape import plugins
 
-from .providers import HardhatNetworkConfig, HardhatProvider
+from .providers import (
+    HardhatNetworkConfig,
+    HardhatProvider,
+    HardhatProviderError,
+    HardhatSubprocessError,
+)
 
 
 @plugins.register(plugins.Config)
@@ -16,3 +21,11 @@ def config_class():
 @plugins.register(plugins.ProviderPlugin)
 def providers():
     yield "ethereum", "development", HardhatProvider
+
+
+__all__ = [
+    "HardhatNetworkConfig",
+    "HardhatProvider",
+    "HardhatProviderError",
+    "HardhatSubprocessError",
+]

--- a/tests/test_hardhat.py
+++ b/tests/test_hardhat.py
@@ -5,7 +5,7 @@ import pytest  # type: ignore
 from conftest import get_network_config
 from hexbytes import HexBytes
 
-from ape_hardhat import HardhatProvider
+from ape_hardhat import HardhatProvider, HardhatProviderError
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
 TEST_CUSTOM_PORT = 8555  # vs. Hardhat's default of 8545
@@ -139,5 +139,5 @@ def test_unlock_account(hardhat_provider):
 
 def test_double_connect(hardhat_provider):
     # connect has already been called once as part of the fixture, so connecting again should fail
-    with pytest.raises(RuntimeError):
+    with pytest.raises(HardhatProviderError):
         hardhat_provider.connect()


### PR DESCRIPTION
### What I did

Added Windows support for the Hardhat network provider.

### How I did it

See https://github.com/ApeWorX/ape/issues/91#issuecomment-932458267 for steps on installing Ape on Windows. Once I got that to work, all that was needed was a small amount of OS-specific code to manage the Hardhat process on Windows.

### How to verify it

No CI support yet (blocked by https://github.com/ApeWorX/ape/issues/91) but the test suite is passing locally for me:

```
PS C:\Users\orayo\Documents\steve\ape-hardhat> ..\ape-env\Scripts\pytest.exe
=== test session starts ===
platform win32 -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: C:\Users\orayo\Documents\steve\ape-hardhat, configfile: pytest.ini
plugins: hypothesis-6.23.0, cov-2.12.1, forked-1.3.0, xdist-2.4.0, web3-5.23.1
gw0 [17] / gw1 [17] / gw2 [17] / gw3 [17]
................. [100%]
=== warnings summary ===
tests/test_hardhat.py::test_rpc_methods[get_balance-args1-0]
  c:\users\orayo\documents\steve\ape-env\lib\site-packages\web3\method.py:215: DeprecationWarning: getBalance is deprecated in favor of get_balance
    warnings.warn(

tests/test_hardhat.py::test_rpc_methods[get_nonce-args0-0]
  c:\users\orayo\documents\steve\ape-env\lib\site-packages\web3\method.py:215: DeprecationWarning: getTransactionCount is deprecated in favor of get_transaction_count
    warnings.warn(

tests/test_hardhat.py::test_rpc_methods[get_code-args2-]
  c:\users\orayo\documents\steve\ape-env\lib\site-packages\web3\method.py:215: DeprecationWarning: getCode is deprecated in favor of get_code
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=== 17 passed, 3 warnings in 61.00s (0:01:01) ===
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
