### PR TITLE
feat: new call_hardhat_task method to call into Hardhat JS internals from Python

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -9,3 +9,16 @@ module.exports = {
     },
   },
 };
+
+task("dump-accounts", "Dumps the accounts as JSON for the current project", async (taskArgs, hre) => {
+  const util = require("hardhat/internal/core/providers/util");
+  const { bufferToHex, privateToAddress, toBuffer } = require("ethereumjs-util");
+  const accts = util.normalizeHardhatNetworkAccountsConfig(config.networks.hardhat.accounts);
+  let out = [];
+  for(let acct of accts) {
+    acct.address = bufferToHex(privateToAddress(toBuffer(acct.privateKey)));
+    out.push(acct);
+  }
+  console.log(JSON.stringify(out, null, 2));
+});
+

--- a/tests/test_hardhat.py
+++ b/tests/test_hardhat.py
@@ -141,3 +141,9 @@ def test_double_connect(hardhat_provider):
     # connect has already been called once as part of the fixture, so connecting again should fail
     with pytest.raises(HardhatProviderError):
         hardhat_provider.connect()
+
+
+def test_dump_accounts(hardhat_provider):
+    accts = hardhat_provider.get_accounts()
+    assert len(accts) == 20
+    assert "privateKey" in accts[0]


### PR DESCRIPTION
### What I did

POC for a new `call_hardhat_task` method on the Hardhat provider which allows us to call into Hardhat's JS internals from Python.

### How I did it

This code allows us to roundtrip from Python to Hardhat JS (via writing custom JS code to the config file) and then back to Python (by calling the JS code via subprocess and reading the result as JSON). This was related to the pytest account work. In order to get a list of accounts, I first experimented with adding custom JS task code to Hardhat's config file, then generalized it like this.

**We don't need to land this PR**. I just wanted to save the technique somewhere because it seems useful.

### How to verify it

See new `test_dump_accounts` test.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
