### PR TITLE
chore: replace print statements with debug logging

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
           run: pip install .[lint]
 
         - name: Run MyPy
-          run: mypy .
+          run: mypy . --exclude=build
 
     functional:
         runs-on: ${{ matrix.os }}

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -14,6 +14,7 @@ from subprocess import PIPE, Popen, call
 from typing import Any, List, Optional
 
 from ape.exceptions import ProviderError
+from ape.logging import logger
 from ape_http.providers import DEFAULT_SETTINGS, EthereumProvider, NetworkConfig
 
 EPHEMERAL_PORTS_START = 49152
@@ -96,13 +97,9 @@ def _kill_process(proc):
 class HardhatProviderError(ProviderError):
     """An error related to the Hardhat network provider plugin."""
 
-    pass
-
 
 class HardhatSubprocessError(HardhatProviderError):
     """An error related to launching subprocesses to run Hardhat."""
-
-    pass
 
 
 class HardhatNetworkConfig(NetworkConfig):
@@ -124,7 +121,6 @@ class HardhatProvider(EthereumProvider):
         self.npx_bin = shutil.which("npx")
 
         hardhat_config_file = self.network.config_manager.PROJECT_FOLDER / "hardhat.config.js"
-
         if not hardhat_config_file.is_file():
             hardhat_config_file.write_text(HARDHAT_CONFIG)
 
@@ -193,7 +189,7 @@ class HardhatProvider(EthereumProvider):
                 raise HardhatProviderError(f"Unexpected chain ID: {chain_id}")
             return True
         except Exception as exc:
-            print("Hardhat connection failed:", exc)
+            logger.debug("Hardhat connection failed: %r", exc)
         return False
 
     def connect(self):
@@ -213,7 +209,7 @@ class HardhatProvider(EthereumProvider):
                     self._start_process()
                     break
                 except HardhatSubprocessError as exc:
-                    print("Retrying hardhat subprocess startup:", exc)
+                    logger.info("Retrying hardhat subprocess startup: %r", exc)
 
         # subprocess should be running and receiving network requests at this point
         if not (self.process and self.process.poll() is None and self.port):

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape==0.1.0a23",
+        "eth-ape==0.1.0a24",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape==0.1.0a24",
+        "eth-ape>=0.1.0a25",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",


### PR DESCRIPTION
### What I did

Related issue: #3 

### How I did it

Upgraded to eth-ape==0.1.0a24 for the logger change, then replaced all the print statements with calls to the logger.

I also added `--exclude=build` to the mypy CI job. I guess an unpinned dependency is now upgrading in CI (maybe setuptools?) and as part of the install step it leaves behind a `build` folder for the top level ape_hardhat project, which causes mypy to fail:

```
build/lib/ape_hardhat/__init__.py: error: Duplicate module named "ape_hardhat" (also at "./ape_hardhat/__init__.py")
build/lib/ape_hardhat/__init__.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
```

I couldn't reproduce this behavior locally with the same commands.

### How to verify it

Running `ape console` is now silent, while running `ape console --verbosity=debug` shows the connection retries.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
