### PR TITLE
feat: upgrade and support latest ape

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.0.1
     hooks:
     -   id: check-yaml
 
@@ -10,23 +10,23 @@ repos:
     -   id: seed-isort-config
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.8.0
+    rev: v5.9.3
     hooks:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 20.8b0
+    rev: 21.10b0
     hooks:
       - id: black
         name: black
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.9.2
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.800
+    rev: v0.910-1
     hooks:
     -   id: mypy
 

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -338,15 +338,15 @@ class HardhatProvider(Web3Provider, TestProviderAPI):
 
 def _get_vm_error(web3_value_error: ValueError) -> TransactionError:
     if not len(web3_value_error.args):
-        return VirtualMachineError(web3_value_error)
+        return VirtualMachineError(base_err=web3_value_error)
 
     err_data = web3_value_error.args[0]
     if not isinstance(err_data, dict):
-        return VirtualMachineError(web3_value_error)
+        return VirtualMachineError(base_err=web3_value_error)
 
     message = str(err_data.get("message"))
     if not message:
-        return VirtualMachineError(web3_value_error)
+        return VirtualMachineError(base_err=web3_value_error)
 
     # Handle `ContactLogicError` similary to other providers in `ape`.
     # by stripping off the unnecessary prefix that hardhat has on reverts.

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -13,28 +13,43 @@ import time
 from subprocess import PIPE, Popen, call
 from typing import Any, List, Optional
 
-from ape.exceptions import ProviderError
+from ape.api import ReceiptAPI, TestProviderAPI, TransactionAPI, Web3Provider
+from ape.api.config import ConfigItem
+from ape.exceptions import (
+    ContractLogicError,
+    OutOfGasError,
+    ProviderError,
+    TransactionError,
+    VirtualMachineError,
+)
 from ape.logging import logger
-from ape_http.providers import DEFAULT_SETTINGS, EthereumProvider, NetworkConfig
+from ape.utils import gas_estimation_error_message
+from web3 import HTTPProvider, Web3
+from web3.gas_strategies.rpc import rpc_gas_price_strategy
 
 EPHEMERAL_PORTS_START = 49152
 EPHEMERAL_PORTS_END = 60999
 HARDHAT_CHAIN_ID = 31337
-HARDHAT_CONFIG = """
-// See https://hardhat.org/config/ for config options.
-module.exports = {
-  networks: {
-    hardhat: {
-      hardfork: "london",
-      // base fee of 0 allows use of 0 gas price when testing
-      initialBaseFeePerGas: 0,
-    },
-  },
-};
-"""
 HARDHAT_START_NETWORK_RETRIES = [0.1, 0.2, 0.3, 0.5, 1.0]  # seconds between network retries
 HARDHAT_START_PROCESS_ATTEMPTS = 3  # number of attempts to start subprocess before giving up
 PROCESS_WAIT_TIMEOUT = 15  # seconds to wait for process to terminate
+DEFAULT_SETTINGS = {"uri": "http://localhost:8545"}
+HARDHAT_CONFIG = """
+// See https://hardhat.org/config/ for config options.
+module.exports = {{
+  networks: {{
+    hardhat: {{
+      hardfork: "london",
+      // base fee of 0 allows use of 0 gas price when testing
+      initialBaseFeePerGas: 0,
+      accounts: {{
+        mnemonic: "{0}",
+        path: "m/44'/60'/0'"
+      }}
+    }},
+  }},
+}};
+"""
 
 
 def _signal_handler(signum, frame):
@@ -102,7 +117,7 @@ class HardhatSubprocessError(HardhatProviderError):
     """An error related to launching subprocesses to run Hardhat."""
 
 
-class HardhatNetworkConfig(NetworkConfig):
+class HardhatNetworkConfig(ConfigItem):
     # --port <INT, default from Hardhat is 8545, but our default is to assign a random port number>
     port: Optional[int] = None
 
@@ -111,7 +126,7 @@ class HardhatNetworkConfig(NetworkConfig):
     process_attempts: int = HARDHAT_START_PROCESS_ATTEMPTS
 
 
-class HardhatProvider(EthereumProvider):
+class HardhatProvider(Web3Provider, TestProviderAPI):
     def __post_init__(self):
         self._hardhat_web3 = (
             None  # we need to maintain a separate per-instance web3 client for Hardhat
@@ -122,7 +137,16 @@ class HardhatProvider(EthereumProvider):
 
         hardhat_config_file = self.network.config_manager.PROJECT_FOLDER / "hardhat.config.js"
         if not hardhat_config_file.is_file():
-            hardhat_config_file.write_text(HARDHAT_CONFIG)
+            try:
+                mnemonic = self.network.config_manager.get_config("test")["mnemonic"]
+            except KeyError:
+                # For some reason, test plugins don't show up in child processes
+                from ape_test import Config as TestConfig
+
+                mnemonic = TestConfig.__defaults__["mnemonic"]
+
+            hardhat_config = HARDHAT_CONFIG.format(mnemonic)
+            hardhat_config_file.write_text(hardhat_config)
 
         if not self.npx_bin:
             raise HardhatSubprocessError(
@@ -160,7 +184,8 @@ class HardhatProvider(EthereumProvider):
         connected = False
         for retry_time in self.config.network_retries:
             time.sleep(retry_time)
-            super().connect()
+            self._web3 = Web3(HTTPProvider(self.uri))
+            self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
             connected = self._verify_connection()
             if connected:
                 break
@@ -221,11 +246,7 @@ class HardhatProvider(EthereumProvider):
 
     @property
     def uri(self) -> str:
-        uri = getattr(self.config, self.network.ecosystem.name)[self.network.name]["uri"]
-        if uri != DEFAULT_SETTINGS["uri"]:
-            # the user configured their own URI in the project configs, let's use that
-            return uri
-        elif self.port:
+        if self.port:
             # the user did not override the default URI, and we have a port
             # number, so let's build the URI using that port number
             return f"http://localhost:{self.port}"
@@ -247,8 +268,15 @@ class HardhatProvider(EthereumProvider):
         """
         self._hardhat_web3 = value
 
+    @property
+    def priority_fee(self) -> int:
+        """
+        Priority fee not needed in development network.
+        """
+        return 0
+
     def disconnect(self):
-        super().disconnect()
+        self._web3 = None
         if self.process:
             _kill_process(self.process)
         self.process = None
@@ -266,11 +294,70 @@ class HardhatProvider(EthereumProvider):
     def mine(self, timestamp: Optional[int] = None) -> str:
         return self._make_request("evm_mine", [timestamp] if timestamp else [])
 
-    def snapshot(self) -> int:
+    def snapshot(self) -> str:
         return self._make_request("evm_snapshot", [])
 
-    def revert(self, snapshot_id: int) -> bool:
+    def revert(self, snapshot_id: str):
         return self._make_request("evm_revert", [snapshot_id])
 
     def unlock_account(self, address: str) -> bool:
         return self._make_request("hardhat_impersonateAccount", [address])
+
+    def estimate_gas_cost(self, txn: TransactionAPI) -> int:
+        """
+        Generates and returns an estimate of how much gas is necessary
+        to allow the transaction to complete.
+        The transaction will not be added to the blockchain.
+        """
+        try:
+            return super().estimate_gas_cost(txn)
+        except ValueError as err:
+            tx_error = _get_vm_error(err)
+
+            # If this is the cause of a would-be revert,
+            # raise ContractLogicError so that we can confirm tx-reverts.
+            if isinstance(tx_error, ContractLogicError):
+                raise tx_error from err
+
+            message = gas_estimation_error_message(tx_error)
+            raise TransactionError(base_err=tx_error, message=message) from err
+
+    def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
+        """
+        Creates a new message call transaction or a contract creation
+        for signed transactions.
+        """
+        try:
+            receipt = super().send_transaction(txn)
+        except ValueError as err:
+            raise _get_vm_error(err) from err
+
+        receipt.raise_for_status(txn)
+        return receipt
+
+
+def _get_vm_error(web3_value_error: ValueError) -> TransactionError:
+    if not len(web3_value_error.args):
+        return VirtualMachineError(web3_value_error)
+
+    err_data = web3_value_error.args[0]
+    if not isinstance(err_data, dict):
+        return VirtualMachineError(web3_value_error)
+
+    message = str(err_data.get("message"))
+    if not message:
+        return VirtualMachineError(web3_value_error)
+
+    # Handle `ContactLogicError` similary to other providers in `ape`.
+    # by stripping off the unnecessary prefix that hardhat has on reverts.
+    hardhat_prefix = (
+        "Error: VM Exception while processing transaction: reverted with reason string "
+    )
+    if message.startswith(hardhat_prefix):
+        message = message.replace(hardhat_prefix, "").strip("'")
+        raise ContractLogicError(message)
+
+    elif message == "Transaction ran out of gas":
+        raise OutOfGasError()
+
+    return VirtualMachineError(message=message)

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,6 +6,10 @@ module.exports = {
       hardfork: "london",
       // base fee of 0 allows use of 0 gas price when testing
       initialBaseFeePerGas: 0,
+      accounts: {
+        mnemonic: "test test test test test test test test test test test junk",
+        path: "m/44'/60'/0'"
+      }
     },
   },
 };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.mypy]
+exclude = "build/"
+
 [tool.setuptools_scm]
 write_to = "ape_hardhat/version.py"
 
@@ -11,27 +14,13 @@ write_to = "ape_hardhat/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39']
 include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-  | env
-  | venv
-)/
-'''
 
 [tool.pytest.ini_options]
 addopts = """
     -n auto
+    -p no:ape_test
     --cov-branch
     --cov-report term
     --cov-report html
@@ -46,7 +35,7 @@ markers = "fuzzing: Run Hypothesis fuzz test suite"
 line_length = 100
 force_grid_wrap = 0
 include_trailing_comma = true
-known_third_party = ["setuptools"]
+known_third_party = ["ape", "hexbytes", "pytest", "setuptools", "web3"]
 known_first_party = ["ape_hardhat"]
 multi_line_output = 3
 use_parentheses = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-# if you're experiencing problems with running multiple hardhat processes in
-# parallel, change this line to "-n1" to restrict the test suite to a single process
-addopts = -nauto

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=20.8b1,<21.0",  # auto-formatter and linter
-        "mypy>=0.800,<1.0",  # Static type analyzer
+        "black>=21.10b0,<22.0",  # auto-formatter and linter
+        "mypy>=0.910,<1.0",  # Static type analyzer
         "flake8>=3.8.3,<4.0",  # Style linter
-        "isort>=5.7.0,<6.0",  # Import sorting linter
+        "isort>=5.9.3,<6.0",  # Import sorting linter
     ],
     "doc": [
         "Sphinx>=3.4.3,<4",  # Documentation generator
@@ -66,7 +66,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0a25",
+        "eth-ape>=0.1.0a27",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,25 +2,17 @@ from pathlib import Path
 
 import pytest  # type: ignore
 from ape import Project, networks
-from ape_http.providers import EthereumNetworkConfig
+from ape.managers.project import ProjectManager
 
-from ape_hardhat import HardhatProvider
+from ape_hardhat import HardhatNetworkConfig, HardhatProvider
 
 
-def get_project():
+def get_project() -> ProjectManager:
     return Project(Path(__file__).parent)
 
 
-def get_network_config():
-    p = get_project()
-    config_classes = [
-        klass for (name, klass) in p.config.plugin_manager.config_class if name == "hardhat"
-    ]
-    assert len(config_classes) == 1
-    config = config_classes[0]()
-
-    # need to instantiate a new instance of this otherwise it's shared across HH instances
-    config.ethereum = EthereumNetworkConfig()
+def get_network_config() -> HardhatNetworkConfig:
+    config = HardhatNetworkConfig()
 
     # bump up the timeouts to decrease chance of tests flaking due to race conditions
     config.network_retries = [0.1, 0.2, 0.3, 0.5, 0.5, 1, 1, 1, 1, 1, 1, 5]
@@ -46,6 +38,6 @@ def network_config(project):
 
 @pytest.fixture
 def hardhat_provider(network_api, network_config):
-    hh = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
-    hh.connect()
-    return hh
+    provider = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
+    provider.connect()
+    return provider

--- a/tests/test_hardhat.py
+++ b/tests/test_hardhat.py
@@ -2,33 +2,34 @@ import time
 from pathlib import Path
 
 import pytest  # type: ignore
-from conftest import get_network_config
 from hexbytes import HexBytes
 
 from ape_hardhat import HardhatProvider, HardhatProviderError
 
+from .conftest import get_network_config  # type: ignore
+
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
 TEST_CUSTOM_PORT = 8555  # vs. Hardhat's default of 8545
-TEST_CUSTOM_URI = f"http://localhost:{TEST_CUSTOM_PORT}"
+TEST_CUSTOM_PORT = 8555  # vs. Hardhat's default of 8545
 
 
 def test_instantiation(network_api, network_config):
-    h = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
-    assert h.name == "hardhat"
+    provider = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
+    assert provider.name == "hardhat"
 
 
 def test_connect(network_api, network_config):
-    h = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
-    h.connect()
-    assert h.chain_id == 31337
+    provider = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
+    provider.connect()
+    assert provider.chain_id == 31337
 
 
 def test_disconnect(hardhat_provider):
-    p = hardhat_provider.process
-    assert p
+    process = hardhat_provider.process
+    assert process
     hardhat_provider.disconnect()
     for i in range(15):
-        if hardhat_provider.process is None and p.poll() is not None:
+        if hardhat_provider.process is None and process.poll() is not None:
             return True  # this means the process exited
         time.sleep(0.1)
     raise RuntimeError("hardhat process didn't exit in time")
@@ -57,11 +58,9 @@ def test_rpc_methods(hardhat_provider, method, args, expected):
 
 def test_custom_port(network_api, network_config):
     network_config.port = TEST_CUSTOM_PORT
-    network_config.ethereum.development["uri"] = TEST_CUSTOM_URI
-    h = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
-    h.connect()
-    assert TEST_CUSTOM_URI in h.uri
-    assert h.config.port == TEST_CUSTOM_PORT
+    provider = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
+    provider.connect()
+    assert provider.config.port == TEST_CUSTOM_PORT
 
 
 def test_two_hardhat_instances(network_api):
@@ -70,31 +69,31 @@ def test_two_hardhat_instances(network_api):
     under a single parent process.
     """
     # configure the first provider with a custom port
-    nc1 = get_network_config()
-    nc1.port = TEST_CUSTOM_PORT
-    nc1.ethereum.development["uri"] = TEST_CUSTOM_URI
+    network_config_1 = get_network_config()
+    network_config_1.port = TEST_CUSTOM_PORT
 
     # configure the second provider with the default port
-    nc2 = get_network_config()
+    network_config_2 = get_network_config()
 
     # instantiate the providers (which will start the subprocesses) and validate the ports
-    h1 = HardhatProvider("hardhat", network_api, nc1, {}, Path("."), "")
-    h2 = HardhatProvider("hardhat", network_api, nc2, {}, Path("."), "")
-    h1.connect()
-    h2.connect()
+    provider_1 = HardhatProvider("hardhat", network_api, network_config_1, {}, Path("."), "")
+    provider_2 = HardhatProvider("hardhat", network_api, network_config_2, {}, Path("."), "")
+    provider_1.connect()
+    provider_2.connect()
 
     # validate the two instances, subprocesses, and blockchains are independent of each other
-    assert TEST_CUSTOM_URI in h1.uri
-    assert h1.config.port == h1.port == TEST_CUSTOM_PORT
+    assert provider_1.config.port == provider_1.port == TEST_CUSTOM_PORT
     # the web3 clients must be different in the HH provider instances (compared to the
     # behavior of the EthereumProvider base class, where it's a shared classvar)
-    assert h1._web3 != h2._web3
-    assert h2.port > h1.port  # h2 will have a higher port number in the ephemeral port range
-    h1.mine()
-    h2.mine()
-    hash1 = h1._web3.eth.get_block("latest").hash
-    hash2 = h2._web3.eth.get_block("latest").hash
-    assert hash1 != hash2
+    assert provider_1._web3 != provider_2._web3
+    assert (
+        provider_2.port > provider_1.port
+    )  # h2 will have a higher port number in the ephemeral port range
+    provider_1.mine()
+    provider_2.mine()
+    hash_1 = provider_1._web3.eth.get_block("latest").hash
+    hash_2 = provider_2._web3.eth.get_block("latest").hash
+    assert hash_1 != hash_2
 
 
 def test_set_block_gas_limit(hardhat_provider):
@@ -104,9 +103,9 @@ def test_set_block_gas_limit(hardhat_provider):
 
 def test_sleep(hardhat_provider):
     seconds = 5
-    t1 = hardhat_provider.sleep(seconds)
-    t2 = hardhat_provider.sleep(seconds)
-    assert t2 - t1 == seconds
+    time_1 = hardhat_provider.sleep(seconds)
+    time_2 = hardhat_provider.sleep(seconds)
+    assert time_2 - time_1 == seconds
 
 
 def test_mine(hardhat_provider):


### PR DESCRIPTION
### What I did

fixes: #10 
fixes: #8

Get hardhat off ape http (now called ape geth)

Note: will require another ape release with the PR below merged in

### How I did it

Use base provider from https://github.com/ApeWorX/ape/pull/231

### How to verify it

Checkout PR above and run run some tests / scripts and stuff

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
