### PR TITLE
feat: attempt to use port 8545 before picking a random port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,6 @@ This network provider takes additional Hardhat-specific configuration options. T
 
     hardhat:
       port: 8555
-      ethereum:
-        development:
-          uri: http://localhost:8555
 
 Development
 ***********

--- a/ape_hardhat/exceptions.py
+++ b/ape_hardhat/exceptions.py
@@ -1,0 +1,104 @@
+import time
+from typing import Optional
+
+from ape.exceptions import ProviderError
+
+
+class HardhatProviderError(ProviderError):
+    """
+    An error related to the Hardhat network provider plugin.
+    """
+
+
+class HardhatSubprocessError(HardhatProviderError):
+    """
+    An error related to launching subprocesses to run Hardhat.
+    """
+
+
+class HardhatTimeoutError(HardhatSubprocessError):
+    """
+    A context-manager exception that raises if its operations exceed
+    the given timeout seconds.
+
+    This implementation was inspired from py-geth.
+    """
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        seconds: Optional[int] = None,
+        exception: Optional[Exception] = None,
+        *args,
+        **kwargs,
+    ):
+        self._message = message or "Timed out waiting for process."
+        self._seconds = seconds
+        self._exception = exception
+        self._start_time = None
+        self._is_running = None
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def __str__(self):
+        if self._seconds in [None, ""]:
+            return ""
+
+        return self._message
+
+    @property
+    def expire_at(self) -> float:
+        if self._seconds is None:
+            raise ValueError("Timeouts with 'seconds == None' do not have an expiration time.")
+        elif self._start_time is None:
+            raise ValueError("Timeout has not been started.")
+
+        return self._start_time + self._seconds
+
+    def start(self):
+        if self._is_running is not None:
+            raise ValueError("Timeout has already been started.")
+
+        self._start_time = time.time()
+        self._is_running = True
+
+    def check(self):
+        if self._is_running is None:
+            raise ValueError("Timeout has not been started.")
+
+        elif self._is_running is False:
+            raise ValueError("Timeout has already been cancelled.")
+
+        elif self._seconds is None:
+            return
+
+        elif time.time() > self.expire_at:
+            self._is_running = False
+
+            if isinstance(self._exception, type):
+                raise self._exception(str(self))
+
+            elif isinstance(self._exception, Exception):
+                raise self._exception
+
+            raise self
+
+    def cancel(self):
+        self._is_running = False
+
+
+class RPCTimeoutError(HardhatTimeoutError):
+    def __init__(self, seconds=None, exception=None, *args, **kwargs):
+        error_message = (
+            "Timed out waiting for successful RPC connection to "
+            f"the hardhat node ({seconds} seconds) "
+            "Try 'npx hardhat node' to debug."
+        )
+        super().__init__(
+            message=error_message, seconds=seconds, exception=exception, *args, **kwargs
+        )

--- a/ape_hardhat/exceptions.py
+++ b/ape_hardhat/exceptions.py
@@ -96,7 +96,7 @@ class RPCTimeoutError(HardhatTimeoutError):
     def __init__(self, seconds=None, exception=None, *args, **kwargs):
         error_message = (
             "Timed out waiting for successful RPC connection to "
-            f"the hardhat node ({seconds} seconds) "
+            f"the Hardhat node ({seconds} seconds) "
             "Try 'npx hardhat node' to debug."
         )
         super().__init__(

--- a/ape_hardhat/process.py
+++ b/ape_hardhat/process.py
@@ -1,0 +1,245 @@
+import ctypes
+import platform
+import shutil
+import signal
+import time
+from pathlib import Path
+from subprocess import PIPE, Popen, call
+from typing import Callable, Optional
+from urllib.request import urlopen
+
+from ape.logging import logger
+
+from .exceptions import HardhatSubprocessError, HardhatTimeoutError, RPCTimeoutError
+
+HARDHAT_CHAIN_ID = 31337
+PROCESS_WAIT_TIMEOUT = 15  # seconds to wait for process to terminate
+HARDHAT_CONFIG = """
+// See https://hardhat.org/config/ for config options.
+module.exports = {{
+  networks: {{
+    hardhat: {{
+      hardfork: "london",
+      // base fee of 0 allows use of 0 gas price when testing
+      initialBaseFeePerGas: 0,
+      accounts: {{
+        mnemonic: "{mnemonic}",
+        path: "m/44'/60'/0'",
+        count: {number_of_accounts},
+      }}
+    }},
+  }},
+}};
+"""
+
+
+def _popen(*cmd, preexec_fn: Optional[Callable] = None):
+    return Popen([*cmd], stdin=PIPE, stdout=PIPE, stderr=PIPE, preexec_fn=preexec_fn)
+
+
+def _call(*args):
+    return call([*args], stderr=PIPE, stdout=PIPE, stdin=PIPE)
+
+
+def _linux_set_death_signal():
+    """
+    Automatically sends SIGTERM to child subprocesses when parent process
+    dies (only usable on Linux).
+    """
+    # from: https://stackoverflow.com/a/43152455/75956
+    # the first argument, 1, is the flag for PR_SET_PDEATHSIG
+    # the second argument is what signal to send to child subprocesses
+    libc = ctypes.CDLL("libc.so.6")
+    return libc.prctl(1, signal.SIGTERM)
+
+
+class HardhatConfig:
+    """
+    A class representing the actual 'hardhat.config.js' file.
+    """
+
+    FILE_NAME = "hardhat.config.js"
+
+    def __init__(
+        self,
+        project_path: Path,
+        mnemonic: str,
+        num_of_accounts: int,
+        hard_fork: Optional[str] = None,
+    ):
+        self._base_path = project_path
+        self._mnemonic = mnemonic
+        self._num_of_accounts = num_of_accounts
+        self._hard_fork = hard_fork or "london"
+
+    @property
+    def _content(self) -> str:
+        return HARDHAT_CONFIG.format(
+            mnemonic=self._mnemonic, number_of_accounts=self._num_of_accounts
+        )
+
+    @property
+    def _path(self) -> Path:
+        return self._base_path / self.FILE_NAME
+
+    def write_if_not_exists(self):
+        if not self._path.is_file():
+            self._path.write_text(self._content)
+
+
+class HardhatProcess:
+    """
+    A wrapper class around the hardhat node process.
+    """
+
+    def __init__(
+        self,
+        base_path: Path,
+        port: int,
+        mnemonic: str,
+        number_of_accounts: int,
+        hard_fork: Optional[str] = None,
+    ):
+        self._port = port
+        self._npx_bin = shutil.which("npx")
+        self._process = None
+        self._config_file = HardhatConfig(
+            base_path, mnemonic, number_of_accounts, hard_fork=hard_fork
+        )
+        self._config_file.write_if_not_exists()
+
+        if not self._npx_bin:
+            raise HardhatSubprocessError(
+                "Could not locate NPM executable. See ape-hardhat README for install steps."
+            )
+        elif _call(self._npx_bin, "--version") != 0:
+            raise HardhatSubprocessError(
+                "NPM executable returned error code. See ape-hardhat README for install steps."
+            )
+        elif _call(self._npx_bin, "hardhat", "--version") != 0:
+            raise HardhatSubprocessError(
+                "Missing hardhat NPM package. See ape-hardhat README for install steps."
+            )
+
+    @property
+    def started(self) -> bool:
+        return self._process is not None
+
+    @property
+    def running(self) -> bool:
+        return self._process is not None and self._process.poll() is not None
+
+    @property
+    def is_rpc_ready(self):
+        try:
+            urlopen(f"http://127.0.0.1:{self._port}")
+        except Exception:
+            return False
+        else:
+            return True
+
+    def start(self, timeout=20):
+        """Start the hardhat process and wait for it to respond over the network."""
+
+        # TODO: Add configs to send stdout to logger / redirect to a file in plugin data dir?
+        cmd = [
+            self._npx_bin,
+            "hardhat",
+            "node",
+            "--hostname",
+            "127.0.0.1",
+            "--port",
+            str(self._port),
+        ]
+
+        if self.is_rpc_ready:
+            logger.info(f"Connecting to existing Hardhat node at port '{self._port}'.")
+            process = None  # Not managing the process.
+        else:
+            logger.info(f"Started Hardhat node at port '{self._port}'.")
+
+            pre_exec_fn = _linux_set_death_signal if platform.uname().system == "Linux" else None
+            process = _popen(*cmd, preexec_fn=pre_exec_fn)  # Starts hardhat if it not running.
+
+            if process is None:
+                raise HardhatSubprocessError(
+                    "Failed to start hardhat. Use 'npx hardhat node' to debug."
+                )
+
+            with RPCTimeoutError(seconds=timeout) as _timeout:
+                while True:
+                    if self.is_rpc_ready:
+                        break
+
+                    time.sleep(0.1)
+                    _timeout.check()
+
+        self._process = process
+
+    def stop(self):
+        """Helper function for killing a process and its child subprocesses."""
+        if not self._process:
+            return
+
+        logger.info("Stopping Hardhat node.")
+        _kill_process(self._process)
+        self._process = None
+
+
+def _wait_for_popen(proc, timeout=30):
+    try:
+        with HardhatTimeoutError(seconds=timeout) as _timeout:
+            while proc.poll() is None:
+                time.sleep(0.1)
+                _timeout.check()
+    except HardhatTimeoutError:
+        pass
+
+
+def _kill_process(proc):
+    if platform.uname().system == "Windows":
+        _windows_taskkill(proc.pid)
+        return
+
+    warn_prefix = "Trying to close Hardhat node process."
+
+    def _try_close(timeout, warn_message):
+        try:
+            proc.send_signal(signal.SIGINT)
+            _wait_for_popen(proc, timeout)
+        except KeyboardInterrupt:
+            logger.warning(warn_message)
+
+    try:
+        if proc.poll() is None:
+            _try_close(30, f"{warn_prefix}. Press Ctrl+C 2 more times to force quit")
+
+        if proc.poll() is None:
+            _try_close(10, f"{warn_prefix}. Press Ctrl+C 1 more times to force quit")
+
+        if proc.poll() is None:
+            proc.kill()
+            _wait_for_popen(proc, 2)
+
+    except KeyboardInterrupt:
+        proc.kill()
+
+
+def _windows_taskkill(pid: int) -> None:
+    """
+    Kills the given process and all child processes using taskkill.exe. Used
+    for subprocesses started up on Windows which run in a cmd.exe wrapper that
+    doesn't propagate signals by default (leaving orphaned processes).
+    """
+    taskkill_bin = shutil.which("taskkill")
+    if not taskkill_bin:
+        raise HardhatSubprocessError("Could not find taskkill.exe executable.")
+
+    proc = _popen(
+        taskkill_bin,
+        "/F",  # forcefully terminate
+        "/T",  # terminate child processes
+        "/PID",
+        str(pid),
+    )
+    proc.wait(timeout=PROCESS_WAIT_TIMEOUT)

--- a/ape_hardhat/process.py
+++ b/ape_hardhat/process.py
@@ -89,7 +89,7 @@ class HardhatConfig:
 
 class HardhatProcess:
     """
-    A wrapper class around the hardhat node process.
+    A wrapper class around the Hardhat node process.
     """
 
     def __init__(
@@ -203,19 +203,16 @@ def _kill_process(proc):
 
     warn_prefix = "Trying to close Hardhat node process."
 
-    def _try_close(timeout, warn_message):
+    def _try_close(warn_message):
         try:
             proc.send_signal(signal.SIGINT)
-            _wait_for_popen(proc, timeout)
+            _wait_for_popen(proc, PROCESS_WAIT_TIMEOUT)
         except KeyboardInterrupt:
             logger.warning(warn_message)
 
     try:
         if proc.poll() is None:
-            _try_close(30, f"{warn_prefix}. Press Ctrl+C 2 more times to force quit")
-
-        if proc.poll() is None:
-            _try_close(10, f"{warn_prefix}. Press Ctrl+C 1 more times to force quit")
+            _try_close(f"{warn_prefix}. Press Ctrl+C 1 more times to force quit")
 
         if proc.poll() is None:
             proc.kill()

--- a/ape_hardhat/process.py
+++ b/ape_hardhat/process.py
@@ -33,26 +33,6 @@ module.exports = {{
 """
 
 
-def _popen(*cmd, preexec_fn: Optional[Callable] = None):
-    return Popen([*cmd], stdin=PIPE, stdout=PIPE, stderr=PIPE, preexec_fn=preexec_fn)
-
-
-def _call(*args):
-    return call([*args], stderr=PIPE, stdout=PIPE, stdin=PIPE)
-
-
-def _linux_set_death_signal():
-    """
-    Automatically sends SIGTERM to child subprocesses when parent process
-    dies (only usable on Linux).
-    """
-    # from: https://stackoverflow.com/a/43152455/75956
-    # the first argument, 1, is the flag for PR_SET_PDEATHSIG
-    # the second argument is what signal to send to child subprocesses
-    libc = ctypes.CDLL("libc.so.6")
-    return libc.prctl(1, signal.SIGTERM)
-
-
 class HardhatConfig:
     """
     A class representing the actual 'hardhat.config.js' file.
@@ -186,6 +166,14 @@ class HardhatProcess:
         self._process = None
 
 
+def _popen(*cmd, preexec_fn: Optional[Callable] = None):
+    return Popen([*cmd], stdin=PIPE, stdout=PIPE, stderr=PIPE, preexec_fn=preexec_fn)
+
+
+def _call(*args):
+    return call([*args], stderr=PIPE, stdout=PIPE, stdin=PIPE)
+
+
 def _wait_for_popen(proc, timeout=30):
     try:
         with HardhatTimeoutError(seconds=timeout) as _timeout:
@@ -240,3 +228,15 @@ def _windows_taskkill(pid: int) -> None:
         str(pid),
     )
     proc.wait(timeout=PROCESS_WAIT_TIMEOUT)
+
+
+def _linux_set_death_signal():
+    """
+    Automatically sends SIGTERM to child subprocesses when parent process
+    dies (only usable on Linux).
+    """
+    # from: https://stackoverflow.com/a/43152455/75956
+    # the first argument, 1, is the flag for PR_SET_PDEATHSIG
+    # the second argument is what signal to send to child subprocesses
+    libc = ctypes.CDLL("libc.so.6")
+    return libc.prctl(1, signal.SIGTERM)

--- a/tests/test_hardhat.py
+++ b/tests/test_hardhat.py
@@ -1,16 +1,14 @@
-import time
 from pathlib import Path
 
 import pytest  # type: ignore
 from hexbytes import HexBytes
 
-from ape_hardhat import HardhatProvider, HardhatProviderError
+from ape_hardhat.exceptions import HardhatProviderError
+from ape_hardhat.providers import HardhatProvider
 
 from .conftest import get_network_config  # type: ignore
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
-TEST_CUSTOM_PORT = 8555  # vs. Hardhat's default of 8545
-TEST_CUSTOM_PORT = 8555  # vs. Hardhat's default of 8545
 
 
 def test_instantiation(network_api, network_config):
@@ -24,15 +22,13 @@ def test_connect(network_api, network_config):
     assert provider.chain_id == 31337
 
 
-def test_disconnect(hardhat_provider):
-    process = hardhat_provider.process
-    assert process
-    hardhat_provider.disconnect()
-    for i in range(15):
-        if hardhat_provider.process is None and process.poll() is not None:
-            return True  # this means the process exited
-        time.sleep(0.1)
-    raise RuntimeError("hardhat process didn't exit in time")
+def test_disconnect(network_api, network_config):
+    # Use custom port to prevent connecting to a port used in another test.
+    network_config.port = 8555
+    provider = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
+    provider.connect()
+    provider.disconnect()
+    assert not provider.process
 
 
 def test_gas_price(hardhat_provider):
@@ -41,7 +37,7 @@ def test_gas_price(hardhat_provider):
 
 
 def test_uri(hardhat_provider):
-    assert f"http://localhost:{hardhat_provider.port}" in hardhat_provider.uri
+    assert f"http://127.0.0.1:{hardhat_provider.port}" in hardhat_provider.uri
 
 
 @pytest.mark.parametrize(
@@ -56,44 +52,41 @@ def test_rpc_methods(hardhat_provider, method, args, expected):
     assert method(hardhat_provider, *args) == expected
 
 
-def test_custom_port(network_api, network_config):
-    network_config.port = TEST_CUSTOM_PORT
-    provider = HardhatProvider("hardhat", network_api, network_config, {}, Path("."), "")
-    provider.connect()
-    assert provider.config.port == TEST_CUSTOM_PORT
-
-
-def test_two_hardhat_instances(network_api):
+def test_multiple_hardhat_instances(network_api):
     """
-    Validate the somewhat tricky internal logic of running two Hardhat subprocesses
+    Validate the somewhat tricky internal logic of running multiple Hardhat subprocesses
     under a single parent process.
     """
-    # configure the first provider with a custom port
     network_config_1 = get_network_config()
-    network_config_1.port = TEST_CUSTOM_PORT
-
-    # configure the second provider with the default port
+    network_config_1.port = 8556
     network_config_2 = get_network_config()
+    network_config_2.port = 8557
+    network_config_3 = get_network_config()
+    network_config_3.port = 8558
 
     # instantiate the providers (which will start the subprocesses) and validate the ports
     provider_1 = HardhatProvider("hardhat", network_api, network_config_1, {}, Path("."), "")
     provider_2 = HardhatProvider("hardhat", network_api, network_config_2, {}, Path("."), "")
+    provider_3 = HardhatProvider("hardhat", network_api, network_config_3, {}, Path("."), "")
     provider_1.connect()
     provider_2.connect()
+    provider_3.connect()
 
-    # validate the two instances, subprocesses, and blockchains are independent of each other
-    assert provider_1.config.port == provider_1.port == TEST_CUSTOM_PORT
-    # the web3 clients must be different in the HH provider instances (compared to the
+    # The web3 clients must be different in the HH provider instances (compared to the
     # behavior of the EthereumProvider base class, where it's a shared classvar)
-    assert provider_1._web3 != provider_2._web3
-    assert (
-        provider_2.port > provider_1.port
-    )  # h2 will have a higher port number in the ephemeral port range
+    assert provider_1._web3 != provider_2._web3 != provider_3._web3
+
+    assert provider_1.port == 8556
+    assert provider_2.port == 8557
+    assert provider_3.port == 8558
+
     provider_1.mine()
     provider_2.mine()
+    provider_3.mine()
     hash_1 = provider_1._web3.eth.get_block("latest").hash
     hash_2 = provider_2._web3.eth.get_block("latest").hash
-    assert hash_1 != hash_2
+    hash_3 = provider_3._web3.eth.get_block("latest").hash
+    assert hash_1 != hash_2 != hash_3
 
 
 def test_set_block_gas_limit(hardhat_provider):
@@ -122,14 +115,18 @@ def test_revert_failure(hardhat_provider):
 
 def test_snapshot_and_revert(hardhat_provider):
     snap = hardhat_provider.snapshot()
-    assert snap == 1
-    block1 = hardhat_provider._web3.eth.get_block("latest")
+    assert snap == "1"
+
+    block_1 = hardhat_provider._web3.eth.get_block("latest")
     hardhat_provider.mine()
-    block2 = hardhat_provider._web3.eth.get_block("latest")
-    assert block1.hash != block2.hash and block2.number > block1.number
+    block_2 = hardhat_provider._web3.eth.get_block("latest")
+    assert block_2.number > block_1.number
+    assert block_1.hash != block_2.hash
+
     hardhat_provider.revert(snap)
-    block3 = hardhat_provider._web3.eth.get_block("latest")
-    assert block1.hash == block3.hash and block1.number == block3.number
+    block_3 = hardhat_provider._web3.eth.get_block("latest")
+    assert block_1.number == block_3.number
+    assert block_1.hash == block_3.hash
 
 
 def test_unlock_account(hardhat_provider):


### PR DESCRIPTION
### What I did

fixes: #8
fixes #5 

Before, hardhat always chose an unpredictable, random port.
Now, it will try 8545 first (for provider consistency's sake). If hardhat is already running on that port, it will use that hardhat, otherwise it will do like it did before and pick the random ephemeral port.

### How I did it

* Refactored out all process related stuff to its own module `process.py` which made it easy to add new features to.
**This will also make my hardhat-fork PR super easy to digest!**

### How to verify it

Notice it used 8545 now!
Notice when 8545 is already with a hardhat, it connects to it that way (without process management)
Notice that when a user configures a specific port to use, and that port also has a hardhat already running, it connect to without process management.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
