### PR TITLE
feat: MainnetForkProvider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,12 @@ Use it in most commands like this:
 
     ape console --network :mainnet-fork:hardhat
 
-Specify the upstream archive URL in your ``ape-config.yaml``:
+Specify the upstream archive-data provider in your ``ape-config.yaml``:
 
 .. code-block:: yaml
 
     hardhat:
-      fork:
+      mainnet_fork:
         upstream_provider: infura
 
 Otherwise, it defaults to the default mainnet provider plugin. You can also specify a ``block_number``.

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,33 @@ This network provider takes additional Hardhat-specific configuration options. T
     hardhat:
       port: 8555
 
+Mainnet Fork
+************
+
+The ``ape-hardhat`` plugin also includes a mainnet fork provider. It requires using another provider that has access to mainnet.
+
+Use it in most commands like this:
+
+.. code-block:: bash
+
+    ape console --network :mainnet-fork:hardhat
+
+Specify the upstream archive URL in your ``ape-config.yaml``:
+
+.. code-block:: yaml
+
+    hardhat:
+      fork:
+        upstream_provider: infura
+
+Otherwise, it defaults to the default mainnet provider plugin. You can also specify a ``block_number``.
+
+Note: Make sure you have the upstream provider plugin installed for ape.
+
+.. code-block:: bash
+
+    ape plugins add infura
+
 Development
 ***********
 

--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -6,6 +6,7 @@ implementation written in Node.js).
 from ape import plugins
 
 from .providers import (
+    HardhatMainnetForkProvider,
     HardhatNetworkConfig,
     HardhatProvider,
     HardhatProviderError,
@@ -21,6 +22,7 @@ def config_class():
 @plugins.register(plugins.ProviderPlugin)
 def providers():
     yield "ethereum", "development", HardhatProvider
+    yield "ethereum", "mainnet-fork", HardhatMainnetForkProvider
 
 
 __all__ = [

--- a/ape_hardhat/process.py
+++ b/ape_hardhat/process.py
@@ -79,8 +79,12 @@ class HardhatProcess:
         mnemonic: str,
         number_of_accounts: int,
         hard_fork: Optional[str] = None,
+        fork_url: Optional[str] = None,
+        fork_block_number: Optional[int] = None,
     ):
         self._port = port
+        self._fork_url = fork_url
+        self._fork_block_number = fork_block_number
         self._npx_bin = shutil.which("npx")
         self._process = None
         self._config_file = HardhatConfig(
@@ -131,6 +135,12 @@ class HardhatProcess:
             "--port",
             str(self._port),
         ]
+
+        if self._fork_url is not None:
+            cmd.extend(("--fork", self._fork_url))
+
+        if self._fork_block_number is not None:
+            cmd.extend(("--fork-block-number", self._fork_block_number))
 
         if self.is_rpc_ready:
             logger.info(f"Connecting to existing Hardhat node at port '{self._port}'.")

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -4,7 +4,7 @@ import signal
 import sys
 from typing import Any, List, Optional
 
-from ape.api import ReceiptAPI, TestProviderAPI, TransactionAPI, Web3Provider
+from ape.api import ReceiptAPI, TestProviderAPI, TransactionAPI, UpstreamProvider, Web3Provider
 from ape.api.config import ConfigItem
 from ape.exceptions import ContractLogicError, OutOfGasError, TransactionError, VirtualMachineError
 from ape.logging import logger
@@ -28,6 +28,11 @@ def _signal_handler(signum, frame):
     sys.exit(143 if signum == signal.SIGTERM else 130)
 
 
+class HardhatForkConfig(ConfigItem):
+    upstream_provider: Optional[str] = None
+    block_number: Optional[int] = None
+
+
 class HardhatNetworkConfig(ConfigItem):
     # --port <INT, default from Hardhat is 8545, but our default is to assign a random port number>
     port: Optional[int] = None
@@ -35,6 +40,10 @@ class HardhatNetworkConfig(ConfigItem):
     # Retry strategy configs, try increasing these if you're getting HardhatSubprocessError
     network_retries: List[float] = HARDHAT_START_NETWORK_RETRIES
     process_attempts: int = HARDHAT_START_PROCESS_ATTEMPTS
+
+    # For setting the values in --fork and --fork-block-number command arguments.
+    # Used only in HardhatMainnetForkProvider.
+    mainnet_fork: Optional[HardhatForkConfig] = None
 
 
 class HardhatProvider(Web3Provider, TestProviderAPI):
@@ -133,10 +142,15 @@ class HardhatProvider(Web3Provider, TestProviderAPI):
                 # Pick a random port if one isn't configured and 8545 is taken.
                 self.port = random.randint(EPHEMERAL_PORTS_START, EPHEMERAL_PORTS_END)
 
-        self.process = HardhatProcess(
-            self._base_path, self.port, self._mnemonic, self._number_of_accounts
-        )
+        self.process = self._create_process()
         self.process.start()
+
+    def _create_process(self):
+        """
+        Sub-classes may override this to specify alternative values in the process,
+        such as using mainnet-fork mode.
+        """
+        return HardhatProcess(self._base_path, self.port, self._mnemonic, self._number_of_accounts)
 
     @property
     def uri(self) -> str:
@@ -233,6 +247,44 @@ class HardhatProvider(Web3Provider, TestProviderAPI):
         return receipt
 
 
+class HardhatMainnetForkProvider(HardhatProvider):
+    """
+    A Hardhat provider that uses ``--fork``, like:
+    ``npx hardhat node --fork <upstream-provider-url>``.
+
+    Set the ``upstream_provider`` in the ``hardhat.fork`` config section
+    of your ``ape-config.yaml` file to specify which provider
+    to use as your archive node.
+    """
+
+    def _create_process(self) -> HardhatProcess:
+        mainnet_fork = self.config.mainnet_fork or {}  # type: ignore
+        upstream_provider_name = mainnet_fork.get("upstream_provider")
+        fork_block_num = mainnet_fork.get("block_number")
+        mainnet = self.network.ecosystem.mainnet
+
+        # NOTE: if `upstream_provider_name` is `None`, this gets the default mainnet provider.
+        upstream_provider = mainnet.get_provider(provider_name=upstream_provider_name)
+
+        if not isinstance(upstream_provider, UpstreamProvider):
+            raise HardhatProviderError(
+                f"Provider '{upstream_provider_name}' is not an upstream provider."
+            )
+
+        fork_url = upstream_provider.connection_str
+        if not fork_url:
+            raise HardhatProviderError("Upstream provider does not have a ``connection_str``.")
+
+        return HardhatProcess(
+            self._base_path,
+            self.port,
+            self._mnemonic,
+            self._number_of_accounts,
+            fork_url=fork_url,
+            fork_block_number=fork_block_num,
+        )
+
+
 def _get_vm_error(web3_value_error: ValueError) -> TransactionError:
     if not len(web3_value_error.args):
         return VirtualMachineError(base_err=web3_value_error)
@@ -252,9 +304,9 @@ def _get_vm_error(web3_value_error: ValueError) -> TransactionError:
     )
     if message.startswith(hardhat_prefix):
         message = message.replace(hardhat_prefix, "").strip("'")
-        return ContractLogicError(message)
+        return ContractLogicError(revert_message=message)
     elif "Transaction reverted without a reason string" in message:
-        return ContractLogicError(revert_message="")
+        return ContractLogicError()
 
     elif message == "Transaction ran out of gas":
         return OutOfGasError()

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -252,8 +252,8 @@ class HardhatMainnetForkProvider(HardhatProvider):
     A Hardhat provider that uses ``--fork``, like:
     ``npx hardhat node --fork <upstream-provider-url>``.
 
-    Set the ``upstream_provider`` in the ``hardhat.fork`` config section
-    of your ``ape-config.yaml` file to specify which provider
+    Set the ``upstream_provider`` in the ``hardhat.mainnet_fork`` config
+    section of your ``ape-config.yaml` file to specify which provider
     to use as your archive node.
     """
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0a27",
+        "eth-ape>=0.1.0a29",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",


### PR DESCRIPTION
### What I did

Adds a new provider to `mainnet-fork` network that is for using the `--fork` CLI arg in your hardhat node.

### How I did it

Subclass the provider and yield it from the plugin registration.
The subclass creates the `HardhatProcess` class a little differently, to include the `--fork` parameter.

### How to verify it

Use https://github.com/ApeWorX/ape-infura/pull/13 as your upstream provider
Then, check and see what the block number is from web3! (it should be the latest from mainnet)

Also try commenting out bits of the config file to make sure it uses the default provider (`geth` in most people's cases).

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
