### PR TITLE
docs: change example to reference alchemy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Specify the upstream archive-data provider in your ``ape-config.yaml``:
 
     hardhat:
       mainnet_fork:
-        upstream_provider: infura
+        upstream_provider: alchemy
 
 Otherwise, it defaults to the default mainnet provider plugin. You can also specify a ``block_number``.
 
@@ -76,7 +76,7 @@ Note: Make sure you have the upstream provider plugin installed for ape.
 
 .. code-block:: bash
 
-    ape plugins add infura
+    ape plugins add alchemy
 
 Development
 ***********


### PR DESCRIPTION
### What I did

Now that alchemy is released, we should reference that one instead, as its the community preferred upstream provider

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
