### PR TITLE
fix: bump ape pin to at least 0.1.0b4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0b3",
+        "eth-ape>=0.1.0b4",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",


### PR DESCRIPTION
### What I did

Just realized this required ape beta 4 to work because it imports `SnapshotID`.

### How I did it

Tested on its `0.1.0b3` and realized it didn't work so bumped it to `0.1.0b4`.

### How to verify it

Not really applicable as the last PR already made sure it worked on `b4`.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
