### PR TITLE
feat: raise error when trying to connect fork mode to non-fork node provider

### DIFF
--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -4,6 +4,7 @@ implementation written in Node.js).
 """
 
 from ape import plugins
+from ape.api.networks import LOCAL_NETWORK_NAME
 
 from .providers import (
     HardhatMainnetForkProvider,
@@ -21,7 +22,7 @@ def config_class():
 
 @plugins.register(plugins.ProviderPlugin)
 def providers():
-    yield "ethereum", "development", HardhatProvider
+    yield "ethereum", LOCAL_NETWORK_NAME, HardhatProvider
     yield "ethereum", "mainnet-fork", HardhatMainnetForkProvider
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
     ],
     "dev": [
         "commitizen",  # Manage commits and publishing releases
-        "pre-commit",  # Ensure that linters are run prior to commiting
+        "pre-commit",  # Ensure that linters are run prior to committing
         "pytest-watch",  # `ptw` test watcher/runner
         "IPython",  # Console for interacting
         "ipdb",  # Debugger (Must use `export PYTHONBREAKPOINT=ipdb.set_trace`)
@@ -67,7 +67,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0b4",
+        "eth-ape>=0.1.0b5",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest  # type: ignore
 from ape import Project, networks
+from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.managers.project import ProjectManager
 
 from ape_hardhat import HardhatNetworkConfig, HardhatProvider
@@ -28,7 +29,7 @@ def project():
 
 @pytest.fixture
 def network_api():
-    return networks.ecosystems["ethereum"]["development"]
+    return networks.ecosystems["ethereum"][LOCAL_NETWORK_NAME]
 
 
 @pytest.fixture


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #18 

### How I did it

By checking the block number. Is there an easier way???

### How to verify it

Start hardhat node process in your project

```bash
npx hardhat node
```

In another shell, try running mainnet fork hardhat node via ape:

```bash
ape console --network ::hardhat
```

It should say this:

```
INFO: Connecting to existing Hardhat node at port '8545'.
ERROR: (HardhatProviderError) Attempted to connect Hardhat Mainnet fork provider to different network than upstream. Stop or restart your Hardhat node in Mainnet fork mode to use this provider.
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
