### PR TITLE
feat: add support for fantom networks

### DIFF
--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -24,6 +24,8 @@ def config_class():
 def providers():
     yield "ethereum", LOCAL_NETWORK_NAME, HardhatProvider
     yield "ethereum", "mainnet-fork", HardhatMainnetForkProvider
+    yield "fantom", LOCAL_NETWORK_NAME, HardhatProvider
+    yield "fantom", "opera-fork", HardhatMainnetForkProvider
 
 
 __all__ = [

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -2,7 +2,7 @@ import random
 import shutil
 from pathlib import Path
 from subprocess import PIPE, call
-from typing import Any, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from ape._compat import Literal
 from ape.api import (
@@ -106,7 +106,11 @@ class HardhatNetworkConfig(PluginConfig):
 
     # For setting the values in --fork and --fork-block-number command arguments.
     # Used only in HardhatMainnetForkProvider.
-    mainnet_fork: Optional[HardhatForkConfig] = None
+    # Mapping of ecosystem_name => network_name => HardhatForkConfig
+    fork: Dict[str, Dict[str, HardhatForkConfig]] = {}
+
+    class Config:
+        extra = "allow"
 
 
 def _call(*args):
@@ -341,15 +345,33 @@ class HardhatMainnetForkProvider(HardhatProvider):
     A Hardhat provider that uses ``--fork``, like:
     ``npx hardhat node --fork <upstream-provider-url>``.
 
-    Set the ``upstream_provider`` in the ``hardhat.mainnet_fork`` config
+    Set the ``upstream_provider`` in the ``hardhat.fork`` config
     section of your ``ape-config.yaml` file to specify which provider
     to use as your archive node.
     """
 
     @property
+    def _upstream_network_name(self) -> str:
+        return self.network.name.replace("-fork", "")
+
+    @property
     def _fork_config(self) -> HardhatForkConfig:
         config = cast(HardhatNetworkConfig, self.config)
-        return config.mainnet_fork or HardhatForkConfig()
+
+        # NOTE: Only for backwards compatibility
+        if "mainnet_fork" in config.dict():
+            # TODO: Log a warning
+            return HardhatForkConfig.parse_obj(config.dict().get("mainnet_fork"))
+
+        ecosystem_name = self.network.ecosystem.name
+        if ecosystem_name not in config.fork:
+            return HardhatForkConfig()  # Just use default
+
+        network_name = self._upstream_network_name
+        if network_name not in config.fork[ecosystem_name]:
+            return HardhatForkConfig()  # Just use default
+
+        return config.fork[ecosystem_name][network_name]
 
     @cached_property
     def _upstream_provider(self) -> ProviderAPI:
@@ -368,9 +390,7 @@ class HardhatMainnetForkProvider(HardhatProvider):
         self._upstream_provider.disconnect()
         if self.get_block(0).hash != upstream_genesis_block_hash:
             self.disconnect()
-            raise HardhatProviderError(
-                f"Upstream network is not {self.network.name.replace('-fork', '')}"
-            )
+            raise HardhatProviderError(f"Upstream network is not {self._upstream_network_name}")
 
     def build_command(self) -> List[str]:
         if not isinstance(self._upstream_provider, UpstreamProvider):

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -360,7 +360,10 @@ class HardhatMainnetForkProvider(HardhatProvider):
 
         # NOTE: Only for backwards compatibility
         if "mainnet_fork" in config.dict():
-            # TODO: Log a warning
+            logger.warning(
+                "Use of key `mainnet_fork` in `hardhat` config is deprecated. "
+                "Please use the `fork` key, with `ecosystem` and `network` subkeys."
+            )
             return HardhatForkConfig.parse_obj(config.dict().get("mainnet_fork"))
 
         ecosystem_name = self.network.ecosystem.name

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -391,8 +391,12 @@ class HardhatMainnetForkProvider(HardhatProvider):
         upstream_genesis_block_hash = self._upstream_provider.get_block(0).hash
         self._upstream_provider.disconnect()
         if self.get_block(0).hash != upstream_genesis_block_hash:
-            self.disconnect()
-            raise HardhatProviderError(f"Upstream network is not {self._upstream_network_name}")
+            # self.disconnect()
+            logger.warning(
+                "Upstream network has mismatching genesis block. "
+                "This could be an issue with hardhat."
+            )
+            # raise HardhatProviderError(f"Upstream network is not {self._upstream_network_name}")
 
     def build_command(self) -> List[str]:
         if not isinstance(self._upstream_provider, UpstreamProvider):

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -375,11 +375,10 @@ class HardhatMainnetForkProvider(HardhatProvider):
 
     @cached_property
     def _upstream_provider(self) -> ProviderAPI:
-        # NOTE: if 'upstream_provider_name' is 'None', this gets the default mainnet provider.
-        mainnet = self.network.ecosystem.mainnet
+        upstream_network = self.network.ecosystem.networks[self._upstream_network_name]
         upstream_provider_name = self._fork_config.upstream_provider
-        upstream_provider = mainnet.get_provider(provider_name=upstream_provider_name)
-        return upstream_provider
+        # NOTE: if 'upstream_provider_name' is 'None', this gets the default mainnet provider.
+        return upstream_network.get_provider(provider_name=upstream_provider_name)
 
     def connect(self):
         super().connect()


### PR DESCRIPTION
### What I did
This PR allows supporting the `ape-fantom` plugin, when installed. If it is not installed, there is no adverse effects to the plugin

### How I did it
Added two lines

### How to verify it
Check `ape networks list` with and without `ape-fantom` installed

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
