### PR TITLE
fix: don't convert address if None

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -346,7 +346,10 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         for signed transactions.
         """
 
-        sender = self.conversion_manager.convert(txn.sender, AddressType)
+        sender = txn.sender
+        if sender:
+            sender = self.conversion_manager.convert(txn.sender, AddressType)
+
         if sender in self.unlocked_accounts:
             # Allow for an unsigned transaction
             txn_dict = txn.dict()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,92 @@
 from pathlib import Path
 
 import pytest  # type: ignore
-from ape import Project, accounts, networks
+from ape import Project, networks
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
+from ape.contracts import ContractContainer, ContractInstance
 from ape.managers.project import ProjectManager
+from ethpm_types import ContractType
 
 from ape_hardhat import HardhatProvider
+
+RAW_CONTRACT_TYPE = {
+    "contractName": "TestContract",
+    "sourceId": "TestContract.vy",
+    "deploymentBytecode": {
+        "bytecode": "0x3360005561012656600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd5b61000861012603610008600039610008610126036000f3"  # noqa: E501
+    },
+    "runtimeBytecode": {
+        "bytecode": "0x600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd"  # noqa: E501
+    },
+    "abi": [
+        {
+            "type": "event",
+            "name": "NumberChange",
+            "inputs": [
+                {"name": "prev_num", "type": "uint256", "indexed": False},
+                {"name": "new_num", "type": "uint256", "indexed": True},
+            ],
+            "anonymous": False,
+        },
+        {"type": "constructor", "stateMutability": "nonpayable", "inputs": []},
+        {
+            "type": "function",
+            "name": "set_number",
+            "stateMutability": "nonpayable",
+            "inputs": [{"name": "num", "type": "uint256"}],
+            "outputs": [],
+        },
+        {
+            "type": "function",
+            "name": "owner",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "address"}],
+        },
+        {
+            "type": "function",
+            "name": "my_number",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "uint256"}],
+        },
+        {
+            "type": "function",
+            "name": "prev_number",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "uint256"}],
+        },
+    ],
+    "userdoc": {},
+    "devdoc": {},
+}
+
+
+@pytest.fixture
+def hardhat_connected_from_ape():
+    with networks.parse_network_choice(f"ethereum:{LOCAL_NETWORK_NAME}:hardhat") as provider:
+        yield provider
+
+
+@pytest.fixture
+def contract_type() -> ContractType:
+    return ContractType.parse_obj(RAW_CONTRACT_TYPE)
+
+
+@pytest.fixture
+def contract_container(contract_type) -> ContractContainer:
+    return ContractContainer(contract_type=contract_type)
+
+
+@pytest.fixture
+def contract_instance(owner, contract_container, hardhat_connected_from_ape) -> ContractInstance:
+    return owner.deploy(contract_container)
+
+
+@pytest.fixture
+def test_accounts(accounts):
+    return accounts.test_accounts
 
 
 def get_project() -> ProjectManager:
@@ -20,11 +101,6 @@ def get_hardhat_provider(network_api: NetworkAPI):
         data_folder=Path("."),
         provider_settings={},
     )
-
-
-@pytest.fixture
-def test_accounts():
-    return accounts.test_accounts
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,85 +3,9 @@ from pathlib import Path
 import pytest  # type: ignore
 from ape import Project, accounts, networks
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
-from ape.contracts import ContractContainer, ContractInstance
 from ape.managers.project import ProjectManager
-from ethpm_types import ContractType
 
 from ape_hardhat import HardhatProvider
-
-RAW_CONTRACT_TYPE = {
-    "contractName": "TestContract",
-    "sourceId": "TestContract.vy",
-    "deploymentBytecode": {
-        "bytecode": "0x3360005561012656600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd5b61000861012603610008600039610008610126036000f3"  # noqa: E501
-    },
-    "runtimeBytecode": {
-        "bytecode": "0x600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd"  # noqa: E501
-    },
-    "abi": [
-        {
-            "type": "event",
-            "name": "NumberChange",
-            "inputs": [
-                {"name": "prev_num", "type": "uint256", "indexed": False},
-                {"name": "new_num", "type": "uint256", "indexed": True},
-            ],
-            "anonymous": False,
-        },
-        {"type": "constructor", "stateMutability": "nonpayable", "inputs": []},
-        {
-            "type": "function",
-            "name": "set_number",
-            "stateMutability": "nonpayable",
-            "inputs": [{"name": "num", "type": "uint256"}],
-            "outputs": [],
-        },
-        {
-            "type": "function",
-            "name": "owner",
-            "stateMutability": "view",
-            "inputs": [],
-            "outputs": [{"name": "", "type": "address"}],
-        },
-        {
-            "type": "function",
-            "name": "my_number",
-            "stateMutability": "view",
-            "inputs": [],
-            "outputs": [{"name": "", "type": "uint256"}],
-        },
-        {
-            "type": "function",
-            "name": "prev_number",
-            "stateMutability": "view",
-            "inputs": [],
-            "outputs": [{"name": "", "type": "uint256"}],
-        },
-    ],
-    "userdoc": {},
-    "devdoc": {},
-}
-
-
-@pytest.fixture
-def hardhat_connected_from_ape():
-    with networks.parse_network_choice(f"ethereum:{LOCAL_NETWORK_NAME}:hardhat") as provider:
-        yield provider
-
-
-@pytest.fixture
-def contract_type() -> ContractType:
-    return ContractType.parse_obj(RAW_CONTRACT_TYPE)
-
-
-@pytest.fixture
-def contract_container(contract_type) -> ContractContainer:
-    return ContractContainer(contract_type=contract_type)
-
-
-@pytest.fixture
-def contract_instance(owner, contract_container, hardhat_connected_from_ape) -> ContractInstance:
-    return owner.deploy(contract_container)
 
 
 def get_project() -> ProjectManager:
@@ -98,22 +22,22 @@ def get_hardhat_provider(network_api: NetworkAPI):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def test_accounts():
     return accounts.test_accounts
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def sender(test_accounts):
     return test_accounts[0]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def receiver(test_accounts):
     return test_accounts[1]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def owner(test_accounts):
     return test_accounts[2]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,11 +84,6 @@ def contract_instance(owner, contract_container, hardhat_connected_from_ape) -> 
     return owner.deploy(contract_container)
 
 
-@pytest.fixture
-def test_accounts(accounts):
-    return accounts.test_accounts
-
-
 def get_project() -> ProjectManager:
     return Project(Path(__file__).parent)
 
@@ -101,6 +96,11 @@ def get_hardhat_provider(network_api: NetworkAPI):
         data_folder=Path("."),
         provider_settings={},
     )
+
+
+@pytest.fixture
+def test_accounts(accounts):
+    return accounts.test_accounts
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest  # type: ignore
-from ape import Project, networks
+from ape import Project, accounts, networks
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.contracts import ContractContainer, ContractInstance
 from ape.managers.project import ProjectManager
@@ -99,7 +99,7 @@ def get_hardhat_provider(network_api: NetworkAPI):
 
 
 @pytest.fixture
-def test_accounts(accounts):
+def test_accounts():
     return accounts.test_accounts
 
 

--- a/tests/test_hardhat.py
+++ b/tests/test_hardhat.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
 import pytest
+from ape import accounts
+from ape.exceptions import SignatureError
 from ape.utils import DEFAULT_TEST_MNEMONIC
 from evm_trace import TraceFrame
 from hexbytes import HexBytes
@@ -10,6 +12,11 @@ from ape_hardhat.providers import HARDHAT_CHAIN_ID, HARDHAT_CONFIG_FILE_NAME, Ha
 from tests.conftest import get_hardhat_provider
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
+
+
+@pytest.fixture
+def test_account():
+    return accounts.test_accounts[0]
 
 
 def test_instantiation(hardhat_disconnected):
@@ -151,3 +158,13 @@ def test_get_transaction_trace(hardhat_connected, sender, receiver):
     logs = hardhat_connected.get_transaction_trace(transfer.txn_hash)
     for log in logs:
         assert isinstance(log, TraceFrame)
+
+
+def test_send_transaction(contract_instance, owner):
+    contract_instance.set_number(10, sender=owner)
+    assert contract_instance.my_number() == 10
+
+
+def test_send_transaction_when_no_sender_raises_signature_error(contract_instance):
+    with pytest.raises(SignatureError):
+        contract_instance.set_number(10)

--- a/tests/test_hardhat.py
+++ b/tests/test_hardhat.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-from ape import accounts
 from ape.exceptions import SignatureError
 from ape.utils import DEFAULT_TEST_MNEMONIC
 from evm_trace import TraceFrame
@@ -12,11 +11,6 @@ from ape_hardhat.providers import HARDHAT_CHAIN_ID, HARDHAT_CONFIG_FILE_NAME, Ha
 from tests.conftest import get_hardhat_provider
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
-
-
-@pytest.fixture
-def test_account():
-    return accounts.test_accounts[0]
 
 
 def test_instantiation(hardhat_disconnected):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-from ape.exceptions import SignatureError
 from ape.utils import DEFAULT_TEST_MNEMONIC
 from evm_trace import TraceFrame
 from hexbytes import HexBytes
@@ -152,13 +151,3 @@ def test_get_transaction_trace(hardhat_connected, sender, receiver):
     logs = hardhat_connected.get_transaction_trace(transfer.txn_hash)
     for log in logs:
         assert isinstance(log, TraceFrame)
-
-
-def test_send_transaction(contract_instance, owner):
-    contract_instance.set_number(10, sender=owner)
-    assert contract_instance.my_number() == 10
-
-
-def test_send_transaction_when_no_sender_raises_signature_error(contract_instance):
-    with pytest.raises(SignatureError):
-        contract_instance.set_number(10)

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,0 +1,89 @@
+import pytest
+from ape import networks
+from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.contracts import ContractContainer, ContractInstance
+from ape.exceptions import SignatureError
+from ethpm_types import ContractType
+
+RAW_CONTRACT_TYPE = {
+    "contractName": "TestContract",
+    "sourceId": "TestContract.vy",
+    "deploymentBytecode": {
+        "bytecode": "0x3360005561012656600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd5b61000861012603610008600039610008610126036000f3"  # noqa: E501
+    },
+    "runtimeBytecode": {
+        "bytecode": "0x600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd"  # noqa: E501
+    },
+    "abi": [
+        {
+            "type": "event",
+            "name": "NumberChange",
+            "inputs": [
+                {"name": "prev_num", "type": "uint256", "indexed": False},
+                {"name": "new_num", "type": "uint256", "indexed": True},
+            ],
+            "anonymous": False,
+        },
+        {"type": "constructor", "stateMutability": "nonpayable", "inputs": []},
+        {
+            "type": "function",
+            "name": "set_number",
+            "stateMutability": "nonpayable",
+            "inputs": [{"name": "num", "type": "uint256"}],
+            "outputs": [],
+        },
+        {
+            "type": "function",
+            "name": "owner",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "address"}],
+        },
+        {
+            "type": "function",
+            "name": "my_number",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "uint256"}],
+        },
+        {
+            "type": "function",
+            "name": "prev_number",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "uint256"}],
+        },
+    ],
+    "userdoc": {},
+    "devdoc": {},
+}
+
+
+@pytest.fixture(scope="module")
+def contract_type() -> ContractType:
+    return ContractType.parse_obj(RAW_CONTRACT_TYPE)
+
+
+@pytest.fixture(scope="module")
+def contract_container(contract_type) -> ContractContainer:
+    return ContractContainer(contract_type=contract_type)
+
+
+@pytest.fixture(scope="module")
+def contract_instance(owner, contract_container, hardhat_connected_from_ape) -> ContractInstance:
+    return owner.deploy(contract_container)
+
+
+@pytest.fixture(scope="module")
+def hardhat_connected_from_ape():
+    with networks.parse_network_choice(f"ethereum:{LOCAL_NETWORK_NAME}:hardhat") as provider:
+        yield provider
+
+
+def test_send_transaction(contract_instance, owner):
+    contract_instance.set_number(10, sender=owner)
+    assert contract_instance.my_number() == 10
+
+    # Have to be in the same test because of X-dist complications
+    with pytest.raises(SignatureError):
+        contract_instance.set_number(20)


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
This fixes an issue raised in ape: https://github.com/ApeWorX/ape/issues/646

### How I did it

Check if not None before trying to conver.

### How to verify it

Error should be the normal SignatureError.
See tests added!

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
