### PR TITLE
fix: contract impersonated transactions fail with incorrect chainID

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -135,8 +135,8 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     @property
     def chain_id(self) -> int:  # type: ignore
-        if hasattr(self._web3, "eth"):
-            return self._web3.eth.chain_id
+        if hasattr(self.web3, "eth"):
+            return self.web3.eth.chain_id
         else:
             return HARDHAT_CHAIN_ID
 

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -3,6 +3,7 @@ import shutil
 from pathlib import Path
 from subprocess import PIPE, call
 from typing import Any, Dict, Iterator, List, Optional, Union, cast
+#from ape import providers
 
 from ape._compat import Literal
 from ape.api import (
@@ -352,12 +353,9 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         if sender in self.unlocked_accounts:
             # Allow for an unsigned transaction
+            txn = self.prepare_transaction(txn)
             txn_dict = txn.dict()
 
-            if txn_dict["chainId"] is not self.chain_id:
-                txn_dict["chainId"] = self.chain_id
-                txn_dict["maxFeePerGas"] = 0
-                txn_dict["maxPriorityFeePerGas"] = 0
             try:
                 txn_hash = self._web3.eth.send_transaction(txn_dict)  # type: ignore
             except ValueError as err:

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -135,7 +135,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     @property
     def chain_id(self) -> int:
-        if self._web3:
+        if self._web3 and hasattr(self._web3, "eth"):
             return self._web3.eth.chain_id
         else:
             return HARDHAT_CHAIN_ID

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -354,6 +354,10 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             # Allow for an unsigned transaction
             txn_dict = txn.dict()
 
+            if txn_dict['chainId'] is not self.chain_id:
+                txn_dict['chainId'] = self.chain_id
+                txn_dict['maxFeePerGas'] = 0
+                txn_dict['maxPriorityFeePerGas'] = 0
             try:
                 txn_hash = self._web3.eth.send_transaction(txn_dict)  # type: ignore
             except ValueError as err:

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -36,7 +36,6 @@ from .exceptions import HardhatNotInstalledError, HardhatProviderError, HardhatS
 # from ape import providers
 
 
-
 EPHEMERAL_PORTS_START = 49152
 EPHEMERAL_PORTS_END = 60999
 HARDHAT_START_NETWORK_RETRIES = [0.1, 0.2, 0.3, 0.5, 1.0]  # seconds between network retries

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -140,7 +140,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     @property
     def chain_id(self) -> int:
-        if hasattr(self._web3, "eth"):
+        if self._web3:
             return self._web3.eth.chain_id
         else:
             return HARDHAT_CHAIN_ID

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -3,7 +3,8 @@ import shutil
 from pathlib import Path
 from subprocess import PIPE, call
 from typing import Any, Dict, Iterator, List, Optional, Union, cast
-#from ape import providers
+
+# from ape import providers
 
 from ape._compat import Literal
 from ape.api import (

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -354,10 +354,10 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             # Allow for an unsigned transaction
             txn_dict = txn.dict()
 
-            if txn_dict['chainId'] is not self.chain_id:
-                txn_dict['chainId'] = self.chain_id
-                txn_dict['maxFeePerGas'] = 0
-                txn_dict['maxPriorityFeePerGas'] = 0
+            if txn_dict["chainId"] is not self.chain_id:
+                txn_dict["chainId"] = self.chain_id
+                txn_dict["maxFeePerGas"] = 0
+                txn_dict["maxPriorityFeePerGas"] = 0
             try:
                 txn_hash = self._web3.eth.send_transaction(txn_dict)  # type: ignore
             except ValueError as err:

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -33,7 +33,6 @@ from web3.gas_strategies.rpc import rpc_gas_price_strategy
 
 from .exceptions import HardhatNotInstalledError, HardhatProviderError, HardhatSubprocessError
 
-
 EPHEMERAL_PORTS_START = 49152
 EPHEMERAL_PORTS_END = 60999
 HARDHAT_START_NETWORK_RETRIES = [0.1, 0.2, 0.3, 0.5, 1.0]  # seconds between network retries

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from subprocess import PIPE, call
 from typing import Any, Dict, Iterator, List, Optional, Union, cast
 
-# from ape import providers
-
 from ape._compat import Literal
 from ape.api import (
     PluginConfig,
@@ -34,6 +32,10 @@ from web3 import HTTPProvider, Web3
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 
 from .exceptions import HardhatNotInstalledError, HardhatProviderError, HardhatSubprocessError
+
+# from ape import providers
+
+
 
 EPHEMERAL_PORTS_START = 49152
 EPHEMERAL_PORTS_END = 60999

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -33,8 +33,6 @@ from web3.gas_strategies.rpc import rpc_gas_price_strategy
 
 from .exceptions import HardhatNotInstalledError, HardhatProviderError, HardhatSubprocessError
 
-# from ape import providers
-
 
 EPHEMERAL_PORTS_START = 49152
 EPHEMERAL_PORTS_END = 60999

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -134,8 +134,8 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         return "Hardhat node"
 
     @property
-    def chain_id(self) -> int:
-        if self._web3 and hasattr(self._web3, "eth"):
+    def chain_id(self) -> int:  # type: ignore
+        if hasattr(self._web3, "eth"):
             return self._web3.eth.chain_id
         else:
             return HARDHAT_CHAIN_ID

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,63 @@ def get_hardhat_provider(network_api: NetworkAPI):
     )
 
 
+RAW_CONTRACT_TYPE = {
+    "contractName": "TestContract",
+    "sourceId": "TestContract.vy",
+    "deploymentBytecode": {
+        "bytecode": "0x3360005561012656600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd5b61000861012603610008600039610008610126036000f3"  # noqa: E501
+    },
+    "runtimeBytecode": {
+        "bytecode": "0x600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd"  # noqa: E501
+    },
+    "abi": [
+        {
+            "type": "event",
+            "name": "NumberChange",
+            "inputs": [
+                {"name": "prev_num", "type": "uint256", "indexed": False},
+                {"name": "new_num", "type": "uint256", "indexed": True},
+            ],
+            "anonymous": False,
+        },
+        {"type": "constructor", "stateMutability": "nonpayable", "inputs": []},
+        {
+            "type": "function",
+            "name": "set_number",
+            "stateMutability": "nonpayable",
+            "inputs": [{"name": "num", "type": "uint256"}],
+            "outputs": [],
+        },
+        {
+            "type": "function",
+            "name": "owner",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "address"}],
+        },
+        {
+            "type": "function",
+            "name": "my_number",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "uint256"}],
+        },
+        {
+            "type": "function",
+            "name": "prev_number",
+            "stateMutability": "view",
+            "inputs": [],
+            "outputs": [{"name": "", "type": "uint256"}],
+        },
+    ],
+    "userdoc": {},
+    "devdoc": {},
+}
+
+@pytest.fixture(scope="session")
+def raw_contract_type():
+    return RAW_CONTRACT_TYPE
+
 @pytest.fixture(scope="session")
 def test_accounts():
     return ape.accounts.test_accounts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,9 +75,11 @@ RAW_CONTRACT_TYPE = {
     "devdoc": {},
 }
 
+
 @pytest.fixture(scope="session")
 def raw_contract_type():
     return RAW_CONTRACT_TYPE
+
 
 @pytest.fixture(scope="session")
 def test_accounts():

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -54,7 +54,7 @@ def contract_container(contract_type) -> ContractContainer:
 def contract_instance(owner, contract_container, mainnet_fork_provider) -> ContractInstance:
     return owner.deploy(contract_container)
 
-@pytest.fixture()
+
 def create_fork_provider(network_api, port):
     provider = HardhatMainnetForkProvider(
         name="hardhat",
@@ -75,7 +75,9 @@ def test_reset_fork(networks, mainnet_fork_provider):
     assert block_num_after_reset < prev_block_num
 
 
-def test_transaction_contract_as_sender(contract_instance, mainnet_fork_provider):
+def test_transaction_contract_as_sender(networks, contract_instance, mainnet_fork_provider):
+    orig_provider = networks.active_provider
+    networks.active_provider = mainnet_fork_provider
     assert contract_instance
     # contract_instance.set_number(10, sender=contract_instance)
     # assert contract_instance.my_number() == 10

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -30,7 +30,7 @@ def create_mainnet_fork_provider(network_api):
         provider_settings={},
     )
 
-
+@alchemy_xfail
 def test_request_timeout(mainnet_fork_provider, config, network_api):
     actual = mainnet_fork_provider.web3.provider._request_kwargs["timeout"]  # type: ignore
     expected = 360  # Value set in `ape-config.yaml`
@@ -58,7 +58,7 @@ def contract_container(contract_type) -> ContractContainer:
 def contract_instance(owner, contract_container, mainnet_fork_provider) -> ContractInstance:
     return owner.deploy(contract_container)
 
-
+@alchemy_xfail
 def create_fork_provider(network_api, port):
     provider = HardhatMainnetForkProvider(
         name="hardhat",
@@ -80,9 +80,10 @@ def test_reset_fork(networks, mainnet_fork_provider):
     assert block_num_after_reset < prev_block_num
 
 
-def test_transaction_contract_as_sender(networks, contract_instance, mainnet_fork_provider):
-    # orig_provider = networks.active_provider
-    networks.active_provider = mainnet_fork_provider
+def test_transaction_contract_as_sender(network_api, contract_instance, provider):
+    provider = get_hardhat_provider(network_api)
+    provider.connect()
+    networks.active_provider = provider
     assert contract_instance
     # contract_instance.set_number(10, sender=contract_instance)
     # assert contract_instance.my_number() == 10

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -2,10 +2,7 @@ from pathlib import Path
 
 import ape
 import pytest
-from ape import networks
-from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractContainer, ContractInstance
-from ape.exceptions import SignatureError
 from ethpm_types import ContractType
 
 from ape_hardhat.providers import HardhatMainnetForkProvider
@@ -76,7 +73,7 @@ def test_reset_fork(networks, mainnet_fork_provider):
 
 
 def test_transaction_contract_as_sender(networks, contract_instance, mainnet_fork_provider):
-    orig_provider = networks.active_provider
+    # orig_provider = networks.active_provider
     networks.active_provider = mainnet_fork_provider
     assert contract_instance
     # contract_instance.set_number(10, sender=contract_instance)

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -2,6 +2,11 @@ from pathlib import Path
 
 import ape
 import pytest
+from ape import networks
+from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.contracts import ContractContainer, ContractInstance
+from ape.exceptions import SignatureError
+from ethpm_types import ContractType
 
 from ape_hardhat.providers import HardhatMainnetForkProvider
 
@@ -35,6 +40,21 @@ def mainnet_fork_provider(networks):
     provider.disconnect()
 
 
+@pytest.fixture(scope="module")
+def contract_type(raw_contract_type) -> ContractType:
+    return ContractType.parse_obj(raw_contract_type)
+
+
+@pytest.fixture(scope="module")
+def contract_container(contract_type) -> ContractContainer:
+    return ContractContainer(contract_type=contract_type)
+
+
+@pytest.fixture()
+def contract_instance(owner, contract_container, mainnet_fork_provider) -> ContractInstance:
+    return owner.deploy(contract_container)
+
+@pytest.fixture()
 def create_fork_provider(network_api, port):
     provider = HardhatMainnetForkProvider(
         name="hardhat",
@@ -53,3 +73,9 @@ def test_reset_fork(networks, mainnet_fork_provider):
     mainnet_fork_provider.reset_fork()
     block_num_after_reset = mainnet_fork_provider.get_block("latest").number
     assert block_num_after_reset < prev_block_num
+
+
+def test_transaction_contract_as_sender(contract_instance, mainnet_fork_provider):
+    assert contract_instance
+    # contract_instance.set_number(10, sender=contract_instance)
+    # assert contract_instance.my_number() == 10

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -5,63 +5,10 @@ from ape.contracts import ContractContainer, ContractInstance
 from ape.exceptions import SignatureError
 from ethpm_types import ContractType
 
-RAW_CONTRACT_TYPE = {
-    "contractName": "TestContract",
-    "sourceId": "TestContract.vy",
-    "deploymentBytecode": {
-        "bytecode": "0x3360005561012656600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd5b61000861012603610008600039610008610126036000f3"  # noqa: E501
-    },
-    "runtimeBytecode": {
-        "bytecode": "0x600436101561000d57610113565b600035601c52600051346101195763d6d1ee148114156100c9576000543314610075576308c379a061014052602061016052600b610180527f21617574686f72697a65640000000000000000000000000000000000000000006101a05261018050606461015cfd5b60056004351815610119576001546002556004356001556004357f2295d5ec33e3af0d43cc4b73aa3cd7d784150fe365cbdb4b4fd338220e4f135761014080808060025481525050602090509050610140a2005b638da5cb5b8114156100e15760005460005260206000f35b63be23d7b98114156100f95760015460005260206000f35b632b3979478114156101115760025460005260206000f35b505b60006000fd5b600080fd"  # noqa: E501
-    },
-    "abi": [
-        {
-            "type": "event",
-            "name": "NumberChange",
-            "inputs": [
-                {"name": "prev_num", "type": "uint256", "indexed": False},
-                {"name": "new_num", "type": "uint256", "indexed": True},
-            ],
-            "anonymous": False,
-        },
-        {"type": "constructor", "stateMutability": "nonpayable", "inputs": []},
-        {
-            "type": "function",
-            "name": "set_number",
-            "stateMutability": "nonpayable",
-            "inputs": [{"name": "num", "type": "uint256"}],
-            "outputs": [],
-        },
-        {
-            "type": "function",
-            "name": "owner",
-            "stateMutability": "view",
-            "inputs": [],
-            "outputs": [{"name": "", "type": "address"}],
-        },
-        {
-            "type": "function",
-            "name": "my_number",
-            "stateMutability": "view",
-            "inputs": [],
-            "outputs": [{"name": "", "type": "uint256"}],
-        },
-        {
-            "type": "function",
-            "name": "prev_number",
-            "stateMutability": "view",
-            "inputs": [],
-            "outputs": [{"name": "", "type": "uint256"}],
-        },
-    ],
-    "userdoc": {},
-    "devdoc": {},
-}
-
 
 @pytest.fixture(scope="module")
-def contract_type() -> ContractType:
-    return ContractType.parse_obj(RAW_CONTRACT_TYPE)
+def contract_type(raw_contract_type) -> ContractType:
+    return ContractType.parse_obj(raw_contract_type)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: https://github.com/ApeWorX/ape-hardhat/issues/38
fixes: https://github.com/ApeWorX/ape/issues/606

### How I did it
detect chainID for transaction and if it is not self.chain_id then set it to self.chain_id and set the gas for transactions to zero

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
