### PR TITLE
feat: support forking Ethereum testnets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,6 +72,8 @@ jobs:
 
         - name: Run Tests
           run: pytest -m "not fuzzing"
+          env:
+            WEB3_ALCHEMY_PROJECT_ID: ${{ secrets.WEB3_ALCHEMY_PROJECT_ID }}
 
 # NOTE: uncomment this block after you've marked tests with @pytest.mark.fuzzing
 #    fuzzing:

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Hardhat network provider plugin for Ape. Hardhat is a development framework writ
 
 ## Dependencies
 
-* `python3 <https://www.python.org/downloads>`_ version 3.7 or greater, python3-dev
-* Node.js, NPM, and Hardhat. See Hardhat's `Installation <https://hardhat.org/getting-started/#installation>`_ documentation for steps.
+* [python3](https://www.python.org/downloads) version 3.7 or greater, python3-dev
+* Node.js, NPM, and Hardhat. See Hardhat's [Installation](https://hardhat.org/getting-started/#installation>) documentation for steps.
 
 ## Installation
 
 ### via ``pip``
 
-You can install the latest release via `pip <https://pypi.org/project/pip/>`_:
+You can install the latest release via [`pip`](https://pypi.org/project/pip/):
 
 ```bash
 pip install ape-hardhat
@@ -19,7 +19,7 @@ pip install ape-hardhat
 
 ### via ``setuptools``
 
-You can clone the repository and use `setuptools <https://github.com/pypa/setuptools>`_ for the most up-to-date version:
+You can clone the repository and use [`setuptools`](https://github.com/pypa/setuptools) for the most up-to-date version:
 
 ```bash
 git clone https://github.com/ApeWorX/ape-hardhat.git

--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -5,6 +5,7 @@ implementation written in Node.js).
 
 from ape import plugins
 from ape.api.networks import LOCAL_NETWORK_NAME
+from ape_ethereum.ecosystem import NETWORKS
 
 from .providers import (
     HardhatForkProvider,
@@ -23,7 +24,10 @@ def config_class():
 @plugins.register(plugins.ProviderPlugin)
 def providers():
     yield "ethereum", LOCAL_NETWORK_NAME, HardhatProvider
-    yield "ethereum", "mainnet-fork", HardhatForkProvider
+
+    for network in NETWORKS:
+        yield "ethereum", f"{network}-fork", HardhatForkProvider
+
     yield "fantom", LOCAL_NETWORK_NAME, HardhatProvider
     yield "fantom", "opera-fork", HardhatForkProvider
 

--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -7,7 +7,7 @@ from ape import plugins
 from ape.api.networks import LOCAL_NETWORK_NAME
 
 from .providers import (
-    HardhatMainnetForkProvider,
+    HardhatForkProvider,
     HardhatNetworkConfig,
     HardhatProvider,
     HardhatProviderError,
@@ -23,9 +23,9 @@ def config_class():
 @plugins.register(plugins.ProviderPlugin)
 def providers():
     yield "ethereum", LOCAL_NETWORK_NAME, HardhatProvider
-    yield "ethereum", "mainnet-fork", HardhatMainnetForkProvider
+    yield "ethereum", "mainnet-fork", HardhatForkProvider
     yield "fantom", LOCAL_NETWORK_NAME, HardhatProvider
-    yield "fantom", "opera-fork", HardhatMainnetForkProvider
+    yield "fantom", "opera-fork", HardhatForkProvider
 
 
 __all__ = [

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -438,12 +438,10 @@ class HardhatMainnetForkProvider(HardhatProvider):
         upstream_genesis_block_hash = self._upstream_provider.get_block(0).hash
         self._upstream_provider.disconnect()
         if self.get_block(0).hash != upstream_genesis_block_hash:
-            # self.disconnect()
             logger.warning(
                 "Upstream network has mismatching genesis block. "
                 "This could be an issue with hardhat."
             )
-            # raise HardhatProviderError(f"Upstream network is not {self._upstream_network_name}")
 
     def build_command(self) -> List[str]:
         if not isinstance(self._upstream_provider, UpstreamProvider):

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -64,8 +64,6 @@ class HardhatConfigJS:
     A class representing the actual ``hardhat.config.js`` file.
     """
 
-    FILE_NAME = "hardhat.config.js"
-
     def __init__(
         self,
         project_path: Path,
@@ -86,7 +84,7 @@ class HardhatConfigJS:
 
     @property
     def _path(self) -> Path:
-        return self._base_path / self.FILE_NAME
+        return self._base_path / HARDHAT_CONFIG_FILE_NAME
 
     def write_if_not_exists(self):
         if not self._path.is_file():

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -104,7 +104,7 @@ class HardhatNetworkConfig(PluginConfig):
     process_attempts: int = HARDHAT_START_PROCESS_ATTEMPTS
 
     # For setting the values in --fork and --fork-block-number command arguments.
-    # Used only in HardhatMainnetForkProvider.
+    # Used only in HardhatForkProvider.
     # Mapping of ecosystem_name => network_name => HardhatForkConfig
     fork: Dict[str, Dict[str, HardhatForkConfig]] = {}
 
@@ -385,7 +385,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             yield TraceFrame(**log)
 
 
-class HardhatMainnetForkProvider(HardhatProvider):
+class HardhatForkProvider(HardhatProvider):
     """
     A Hardhat provider that uses ``--fork``, like:
     ``npx hardhat node --fork <upstream-provider-url>``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 addopts = """
-    -n auto
     -p no:ape_test
     --cov-branch
     --cov-report term

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 addopts = """
+    -n auto
     -p no:ape_test
     --cov-branch
     --cov-report term

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ extras_require = {
         "pytest-xdist",  # multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
+        "ape-alchemy",
     ],
     "lint": [
         "black>=22.3.0,<23.0",  # auto-formatter and linter

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -1,0 +1,13 @@
+hardhat:
+  fork:
+    ethereum:
+      mainnet:
+        upstream_provider: alchemy
+      rinkeby:
+        upstream_provider: alchemy
+      kovan:
+        upstream_provider: alchemy
+      ropsten:
+        upstream_provider: alchemy
+      goerli:
+        upstream_provider: alchemy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
+import ape
 import pytest  # type: ignore
-from ape import Project, accounts, networks
 from ape.api.networks import LOCAL_NETWORK_NAME, NetworkAPI
 from ape.managers.project import ProjectManager
 
@@ -9,7 +9,7 @@ from ape_hardhat import HardhatProvider
 
 
 def get_project() -> ProjectManager:
-    return Project(Path(__file__).parent)
+    return ape.Project(Path(__file__).parent)
 
 
 def get_hardhat_provider(network_api: NetworkAPI):
@@ -24,7 +24,7 @@ def get_hardhat_provider(network_api: NetworkAPI):
 
 @pytest.fixture(scope="session")
 def test_accounts():
-    return accounts.test_accounts
+    return ape.accounts.test_accounts
 
 
 @pytest.fixture(scope="session")
@@ -48,7 +48,12 @@ def project():
 
 
 @pytest.fixture(scope="session")
-def network_api():
+def networks():
+    return ape.networks
+
+
+@pytest.fixture(scope="session")
+def network_api(networks):
     return networks.ecosystems["ethereum"][LOCAL_NETWORK_NAME]
 
 
@@ -63,7 +68,7 @@ def hardhat_connected(network_api):
     provider = get_hardhat_provider(network_api)
     provider.port = "auto"  # For better multi-processing support
     provider.connect()
-    networks.active_provider = provider
+    ape.networks.active_provider = provider
     try:
         yield provider
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,19 +53,19 @@ def networks():
 
 
 @pytest.fixture(scope="session")
-def network_api(networks):
+def local_network_api(networks):
     return networks.ecosystems["ethereum"][LOCAL_NETWORK_NAME]
 
 
 @pytest.fixture(scope="session")
-def hardhat_disconnected(network_api):
-    provider = get_hardhat_provider(network_api)
+def hardhat_disconnected(local_network_api):
+    provider = get_hardhat_provider(local_network_api)
     return provider
 
 
 @pytest.fixture(scope="session")
-def hardhat_connected(network_api):
-    provider = get_hardhat_provider(network_api)
+def hardhat_connected(local_network_api):
+    provider = get_hardhat_provider(local_network_api)
     provider.port = "auto"  # For better multi-processing support
     provider.connect()
     ape.networks.active_provider = provider

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -1,21 +1,74 @@
-import os
 from pathlib import Path
 
+import ape
 import pytest
 from ape_ethereum.ecosystem import NETWORKS
 
+from ape_hardhat.providers import HardhatForkProvider
+
 TESTS_DIRECTORY = Path(__file__).parent
+TEST_ADDRESS = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+
+
+@pytest.fixture(scope="module")
+def config():
+    return ape.config
 
 
 @pytest.fixture(autouse=True, scope="module")
-def in_tests_dir():
-    curr_dir = str(Path.cwd())
-    os.chdir(TESTS_DIRECTORY)
-    yield
-    os.chdir(curr_dir)
+def in_tests_dir(config):
+    with config.using_project(TESTS_DIRECTORY):
+        yield
+
+
+@pytest.fixture
+def mainnet_fork_provider(networks):
+    network_api = networks.ecosystems["ethereum"]["mainnet-fork"]
+    provider = HardhatForkProvider(
+        name="hardhat",
+        network=network_api,
+        request_header={},
+        data_folder=Path("."),
+        provider_settings={},
+    )
+    provider.port = 9001
+    provider.connect()
+    yield provider
+    provider.disconnect()
+
+
+def create_fork_provider(network_api, port):
+    provider = HardhatForkProvider(
+        name="hardhat",
+        network=network_api,
+        request_header={},
+        data_folder=Path("."),
+        provider_settings={},
+    )
+    provider.port = port
+    return provider
 
 
 @pytest.mark.parametrize("network", [k for k in NETWORKS.keys()])
-def test_connect(network, networks):
-    with networks.parse_network_choice(f"ethereum:{network}-fork:hardhat") as provider:
-        assert provider.get_block("latest").number > 1
+def test_fork_config(config, network):
+    plugin_config = config.get_config("hardhat")
+    network_config = plugin_config["fork"].get("ethereum", {}).get(network, {})
+    assert network_config["upstream_provider"] == "alchemy", "config not registered"
+
+
+@pytest.mark.parametrize("upstream,port", [("mainnet", 9000), ("rinkeby", 9001)])
+def test_impersonate(networks, test_accounts, upstream, port):
+    network_api = networks.ecosystems["ethereum"][f"{upstream}-fork"]
+    provider = create_fork_provider(network_api, port)
+    provider.connect()
+    orig_provider = networks.active_provider
+    networks.active_provider = provider
+
+    impersonated_account = test_accounts[TEST_ADDRESS]
+    other_account = test_accounts[0]
+    receipt = impersonated_account.transfer(other_account, "1 wei")
+    assert receipt.receiver == other_account
+    assert receipt.sender == impersonated_account
+
+    provider.disconnect()
+    networks.active_provider = orig_provider

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+
+import pytest
+from ape_ethereum.ecosystem import NETWORKS
+
+TESTS_DIRECTORY = Path(__file__).parent
+
+
+@pytest.fixture(autouse=True, scope="module")
+def in_tests_dir():
+    curr_dir = str(Path.cwd())
+    os.chdir(TESTS_DIRECTORY)
+    yield
+    os.chdir(curr_dir)
+
+
+@pytest.mark.parametrize("network", [k for k in NETWORKS.keys()])
+def test_connect(network, networks):
+    with networks.parse_network_choice(f"ethereum:{network}-fork:hardhat") as provider:
+        assert provider.get_block("latest").number > 1

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -16,10 +16,10 @@ def test_instantiation(hardhat_disconnected):
     assert hardhat_disconnected.name == "hardhat"
 
 
-def test_connect_and_disconnect(network_api):
+def test_connect_and_disconnect(local_network_api):
     # Use custom port to prevent connecting to a port used in another test.
 
-    hardhat = get_hardhat_provider(network_api)
+    hardhat = get_hardhat_provider(local_network_api)
     hardhat.port = 8555
     hardhat.connect()
 
@@ -68,15 +68,15 @@ def test_rpc_methods(hardhat_connected, method, args, expected):
     assert method(hardhat_connected, *args) == expected
 
 
-def test_multiple_hardhat_instances(network_api):
+def test_multiple_hardhat_instances(local_network_api):
     """
     Validate the somewhat tricky internal logic of running multiple Hardhat subprocesses
     under a single parent process.
     """
     # instantiate the providers (which will start the subprocesses) and validate the ports
-    provider_1 = get_hardhat_provider(network_api)
-    provider_2 = get_hardhat_provider(network_api)
-    provider_3 = get_hardhat_provider(network_api)
+    provider_1 = get_hardhat_provider(local_network_api)
+    provider_2 = get_hardhat_provider(local_network_api)
+    provider_3 = get_hardhat_provider(local_network_api)
     provider_1.port = 8556
     provider_2.port = 8557
     provider_3.port = 8558


### PR DESCRIPTION
### What I did

Allows forking other Ethereum networks
Required this PR: https://github.com/ApeWorX/ape/pull/691

### How I did it

* Register the Fork provider for other Fork networks in Ethereum
* Inject POA middleware if needed
* Add tests for fork provider

### How to verify it

You should now be able to fork `rinkeby`!
Example config:

```yaml

ethereum:
  default_network: rinkeby-fork
  rinkeby:
    default_provider: alchemy
  rinkeby_fork:
    default_provider: hardhat

  mainnet:
    default_provider: alchemy

hardhat:
  fork:
    ethereum:
      rinkeby:
        upstream_provider: alchemy

      mainnet:
        upstream_provider: alchemy
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
