### PR TITLE
refactor: add web3 timeout 5 min

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -229,7 +229,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if not self.port:
             return
 
-        self._web3 = Web3(HTTPProvider(self.uri))
+        self._web3 = Web3(HTTPProvider(self.uri, request_kwargs={"timeout": 300}))
         if not self._web3.isConnected():
             self._web3 = None
             return


### PR DESCRIPTION
### What I did

Timeout errors would occur frequently during transaction tracing (10 sec default) on a mainnet-fork. Extending the time to 5 mins should reduce the frequency of timeout errors.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
