### PR TITLE
refactor!: change default port for fork provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,12 +119,9 @@ dmypy.json
 version.py
 
 # Ape stuff
-tests/hardhat.config.js
+**/tests/hardhat.config.js
 
 # NPM
-package.json
-package-lock.json
-node_modules/
-
-# Ape stuff
-.build/
+**/package.json
+**/package-lock.json
+**/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -119,7 +119,7 @@ dmypy.json
 version.py
 
 # Ape stuff
-**/tests/hardhat.config.js
+tests/**/hardhat.config.js
 
 # NPM
 **/package.json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,14 @@ from ethpm_types import ContractType
 
 from ape_hardhat import HardhatProvider
 
+TESTS_DIRECTORY = Path(__file__).parent
+
 
 def get_project() -> ProjectManager:
     return ape.Project(Path(__file__).parent)
 
 
-def get_hardhat_provider(network_api: NetworkAPI):
+def create_hardhat_provider(network_api: NetworkAPI):
     return HardhatProvider(
         name="hardhat",
         network=network_api,
@@ -36,6 +38,12 @@ def pytest_runtest_makereport(item, call):
         tr.wasxfail = "reason: Alchemy requests overloaded (likely in CI)"
 
     return tr
+
+
+@pytest.fixture
+def no_config(config):
+    with config.using_project(Path(__file__).parent / "data" / "noconfig"):
+        yield
 
 
 @pytest.fixture(scope="session", params=("solidity", "vyper"))
@@ -107,13 +115,13 @@ def local_network_api(networks):
 
 @pytest.fixture(scope="session")
 def hardhat_disconnected(local_network_api):
-    provider = get_hardhat_provider(local_network_api)
+    provider = create_hardhat_provider(local_network_api)
     return provider
 
 
 @pytest.fixture(scope="session")
 def hardhat_connected(networks, local_network_api):
-    provider = get_hardhat_provider(local_network_api)
+    provider = create_hardhat_provider(local_network_api)
     provider.connect()
     original_provider = networks.active_provider
     networks.active_provider = provider

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -9,7 +9,7 @@ from hexbytes import HexBytes
 
 from ape_hardhat.exceptions import HardhatProviderError
 from ape_hardhat.providers import HARDHAT_CHAIN_ID, HARDHAT_CONFIG_FILE_NAME, HardhatProvider
-from tests.conftest import get_hardhat_provider
+from tests.conftest import create_hardhat_provider
 
 TEST_WALLET_ADDRESS = "0xD9b7fdb3FC0A0Aa3A507dCf0976bc23D49a9C7A3"
 
@@ -18,10 +18,16 @@ def test_instantiation(hardhat_disconnected):
     assert hardhat_disconnected.name == "hardhat"
 
 
+def test_connect_default_port(no_config, local_network_api):
+    hardhat = create_hardhat_provider(local_network_api)
+    hardhat.connect()
+    assert hardhat.port == 8545
+
+
 def test_connect_and_disconnect(local_network_api):
     # Use custom port to prevent connecting to a port used in another test.
 
-    hardhat = get_hardhat_provider(local_network_api)
+    hardhat = create_hardhat_provider(local_network_api)
     hardhat.port = 8555
     hardhat.connect()
 
@@ -76,9 +82,9 @@ def test_multiple_hardhat_instances(local_network_api):
     under a single parent process.
     """
     # instantiate the providers (which will start the subprocesses) and validate the ports
-    provider_1 = get_hardhat_provider(local_network_api)
-    provider_2 = get_hardhat_provider(local_network_api)
-    provider_3 = get_hardhat_provider(local_network_api)
+    provider_1 = create_hardhat_provider(local_network_api)
+    provider_2 = create_hardhat_provider(local_network_api)
+    provider_3 = create_hardhat_provider(local_network_api)
     provider_1.port = 8556
     provider_2.port = 8557
     provider_3.port = 8558
@@ -164,7 +170,7 @@ def test_request_timeout(hardhat_connected, config, local_network_api):
     with tempfile.TemporaryDirectory() as temp_dir_str:
         temp_dir = Path(temp_dir_str)
         with config.using_project(temp_dir):
-            provider = get_hardhat_provider(local_network_api)
+            provider = create_hardhat_provider(local_network_api)
             assert provider.timeout == 30
 
 


### PR DESCRIPTION
### What I did

Changes default port for fork-provider to lessen confusion when not setting the upstream provider or configuring the Hardhat process port.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
