### PR TITLE
refactor: use shared web3provider implementations

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -20,12 +20,11 @@ from ape.exceptions import (
     OutOfGasError,
     ProviderError,
     SubprocessError,
-    TransactionError,
     VirtualMachineError,
 )
 from ape.logging import logger
 from ape.types import AddressType, SnapshotID
-from ape.utils import cached_property, gas_estimation_error_message
+from ape.utils import cached_property
 from ape_test import Config as TestConfig
 from evm_trace import TraceFrame
 from web3 import HTTPProvider, Web3
@@ -330,25 +329,6 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         return result
 
-    def estimate_gas_cost(self, txn: TransactionAPI) -> int:
-        """
-        Generates and returns an estimate of how much gas is necessary
-        to allow the transaction to complete.
-        The transaction will not be added to the blockchain.
-        """
-        try:
-            return super().estimate_gas_cost(txn)
-        except ValueError as err:
-            tx_error = self.get_virtual_machine_error(err)
-
-            # If this is the cause of a would-be revert,
-            # raise ContractLogicError so that we can confirm tx-reverts.
-            if isinstance(tx_error, ContractLogicError):
-                raise tx_error from err
-
-            message = gas_estimation_error_message(tx_error)
-            raise TransactionError(base_err=tx_error, message=message) from err
-
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         """
         Creates a new message call transaction or a contract creation
@@ -360,25 +340,9 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             sender = self.conversion_manager.convert(txn.sender, AddressType)
 
         if sender in self.unlocked_accounts:
-            # Allow for an unsigned transaction
             txn = self.prepare_transaction(txn)
-            txn_dict = txn.dict()
 
-            try:
-                txn_hash = self._web3.eth.send_transaction(txn_dict)  # type: ignore
-            except ValueError as err:
-                raise self.get_virtual_machine_error(err) from err
-
-            receipt = self.get_transaction(
-                txn_hash.hex(), required_confirmations=txn.required_confirmations or 0
-            )
-
-        else:
-            try:
-                receipt = super().send_transaction(txn)
-            except ValueError as err:
-                raise self.get_virtual_machine_error(err) from err
-
+        receipt = super().send_transaction(txn)
         receipt.raise_for_status()
         return receipt
 


### PR DESCRIPTION
### What I did

Mostly deletes some code that is now part of the `Web3Provider`.
NOTE: Requires 0.2.8 of ape and this PR: https://github.com/ApeWorX/ape/pull/775

- [ ] Update ape (once released)

### How I did it

Delete a bunch of unneeded code

### How to verify it

things still work as they did before

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
