### PR TITLE
refactor: handle our own request parameter and return value validations

### DIFF
--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -120,7 +120,18 @@ def test_mine(connected_provider):
     block_num = connected_provider.get_block("latest").number
     connected_provider.mine()
     next_block_num = connected_provider.get_block("latest").number
-    assert next_block_num > block_num
+
+    # NOTE: Uses >= due to x-dist
+    assert next_block_num >= block_num + 1
+
+
+def test_mine_many_blocks(connected_provider):
+    block_num = connected_provider.get_block("latest").number
+    connected_provider.mine(12)
+    next_block_num = connected_provider.get_block("latest").number
+
+    # NOTE: Uses >= due to x-dist
+    assert next_block_num >= block_num + 12
 
 
 def test_revert_failure(connected_provider):


### PR DESCRIPTION
### What I did

Makes severe speed improvements by avoiding Attr dicts from web3.py middleware and handling our own request validation logic. (Thank you @banteg for the suggestions)

Additionally, uses `hardhat_mine` RPC instead of `evm_mine` for performance improvements when mining a lot.

### How I did it

Use `web3.provider` instead of `web3.eth.request_manager`

### How to verify it

Tests!

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
