### PR TITLE
feat:  add parameter block_number to reset_fork(), so blocknumber could be switched during execution

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -522,7 +522,7 @@ class HardhatForkProvider(HardhatProvider):
 
         return cmd
 
-    def reset_fork(self):
+    def reset_fork(self, new_block_number: int):
         self._make_request(
-            "hardhat_reset", [{"jsonRpcUrl": self.fork_url, "blockNumber": self.fork_block_number}]
+            "hardhat_reset", [{"forking":{"jsonRpcUrl": self.fork_url, "blockNumber": new_block_number}}]
         )

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -522,7 +522,7 @@ class HardhatForkProvider(HardhatProvider):
 
         return cmd
 
-    def reset_fork(self, block_number: int=None):
+    def reset_fork(self, block_number: Optional[int]=None):
         if block_number is None:
             block_number = self.fork_block_number
         self._make_request(

--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -522,7 +522,9 @@ class HardhatForkProvider(HardhatProvider):
 
         return cmd
 
-    def reset_fork(self, new_block_number: int):
+    def reset_fork(self, block_number: int=None):
+        if block_number is None:
+            block_number = self.fork_block_number
         self._make_request(
-            "hardhat_reset", [{"forking":{"jsonRpcUrl": self.fork_url, "blockNumber": new_block_number}}]
+            "hardhat_reset", [{"forking":{"jsonRpcUrl": self.fork_url, "blockNumber": block_number}}]
         )

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -74,6 +74,19 @@ def test_reset_fork(networks, create_fork_provider):
     assert block_num_after_reset < prev_block_num
     provider.disconnect()
 
+    
+@pytest.mark.fork
+def test_reset_fork_specify_block_number(networks, create_fork_provider):
+    provider = create_fork_provider(9020)
+    provider.connect()
+    provider.mine()
+    prev_block_num = provider.get_block("latest").number
+    new_block_number = prev_block_num - 1
+    provider.reset_fork(block_number=new_block_number)
+    block_num_after_reset = provider.get_block("latest").number
+    assert block_num_after_reset == new_block_number 
+    provider.disconnect()    
+
 
 @pytest.mark.fork
 def test_transaction(owner, fork_contract_instance):


### PR DESCRIPTION
new feature: add parameter new_block_number to reset_fork(), so blocknumber could be switched during execution

### What I did
Draft PR for this discord thread: https://discord.com/channels/922917176040640612/954593641970696292/1001008312076226580
new feature: add parameter new_block_number to reset_fork(), so blocknumber could be switched during execution


