### PR TITLE
chore: update ape-hardhat pins for v0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.3.0,<0.4.0",
+        "eth-ape>=0.4.0,<0.5.0",
         "importlib-metadata ; python_version<'3.8'",
         "evm-trace>=0.1.0.a6",
         "hexbytes",  # Use same as eth-ape

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
         "pytest-xdist",  # multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
-        "ape-alchemy>=0.3.0",  # Needed for forked-network tests
+        "ape-alchemy>=0.4.0",  # Needed for forked-network tests
         "rich",  # Needed for trace tests
     ],
     "lint": [


### PR DESCRIPTION
### What I did
updated pins in setup.py for ape and alchemy

### How I did it
updated setup.py

### How to verify it
github checks and pytest

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
