### PR TITLE
fix: issue with duplicate _make_request helper method

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -2,7 +2,7 @@ import random
 import shutil
 from pathlib import Path
 from subprocess import PIPE, call
-from typing import Any, Dict, Iterator, List, Optional, Union, cast
+from typing import Dict, Iterator, List, Optional, Union, cast
 
 from ape._compat import Literal
 from ape.api import (
@@ -298,12 +298,8 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             str(self.port),
         ]
 
-    def _make_request(self, rpc: str, args: list) -> Any:
-        return self.web3.provider.make_request(rpc, args)  # type: ignore
-
     def set_block_gas_limit(self, gas_limit: int) -> bool:
-        result = self._make_request("evm_setBlockGasLimit", [hex(gas_limit)])
-        return result.get("result") is True
+        return self._make_request("evm_setBlockGasLimit", [hex(gas_limit)]) is True
 
     def set_timestamp(self, new_timestamp: int):
         pending_timestamp = self.get_block("pending").timestamp
@@ -316,23 +312,20 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         self._make_request("hardhat_mine", [num_blocks_arg])
 
     def snapshot(self) -> str:
-        result = self._make_request("evm_snapshot", [])
-        return result["result"]
+        return self._make_request("evm_snapshot", [])
 
     def revert(self, snapshot_id: SnapshotID) -> bool:
         if isinstance(snapshot_id, int):
             snapshot_id = HexBytes(snapshot_id).hex()
 
-        result = self._make_request("evm_revert", [snapshot_id])
-        return result.get("result") is True
+        return self._make_request("evm_revert", [snapshot_id]) is True
 
     def unlock_account(self, address: AddressType) -> bool:
         result = self._make_request("hardhat_impersonateAccount", [address])
-
         if result:
             self.unlocked_accounts.append(address)
 
-        return result.get("result") is True
+        return result is True
 
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         """

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.4.0,<0.5.0",
+        "eth-ape>=0.4.3,<0.5.0",
         "importlib-metadata ; python_version<'3.8'",
         "evm-trace>=0.1.0.a6",
         "hexbytes",  # Use same as eth-ape

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -25,7 +25,7 @@ def fork_contract_instance(owner, contract_container, connected_mainnet_fork_pro
 def test_fork_config(config, network):
     plugin_config = config.get_config("hardhat")
     network_config = plugin_config["fork"].get("ethereum", {}).get(network, {})
-    assert network_config["upstream_provider"] == "alchemy", "config not registered"
+    assert network_config.get("upstream_provider") == "alchemy", "config not registered"
 
 
 @pytest.mark.fork


### PR DESCRIPTION
### What I did

* Issue where having a duplicate helper method _make_request was causing issues
* Issue with traces specifically
* NOTE: Config parsing is also broken and requires https://github.com/ApeWorX/ape/pull/972

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
