### PR TITLE
feat: add raise_on_fail to send_transaction()

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -324,7 +324,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         return result is True
 
-    def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
+    def send_transaction(self, txn: TransactionAPI, raise_on_fail: bool = True) -> ReceiptAPI:
         """
         Creates a new message call transaction or a contract creation
         for signed transactions.
@@ -347,10 +347,12 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             receipt = self.get_receipt(
                 txn_hash.hex(), required_confirmations=txn.required_confirmations or 0
             )
-            receipt.raise_for_status()
+
+            if raise_on_fail:
+                receipt.raise_for_status()
 
         else:
-            receipt = super().send_transaction(txn)
+            receipt = super().send_transaction(txn, raise_on_fail=raise_on_fail)
 
         return receipt
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -202,6 +202,18 @@ def test_contract_revert_no_message(owner, contract_instance):
     assert str(err.value) == "Transaction failed."
 
 
+def test_contract_revert_no_raise(owner, contract_instance):
+    # The Contract raises empty revert when setting number to 5.
+    receipt = contract_instance.setNumber(
+        5,
+        sender=owner,
+        gas_limit=100000,
+        raise_on_fail=False,
+    )
+
+    assert receipt.failed
+
+
 def test_transaction_contract_as_sender(contract_instance, connected_provider):
     # Set balance so test wouldn't normally fail from lack of funds
     connected_provider.set_balance(contract_instance.address, "1000 ETH")


### PR DESCRIPTION
### What I did

Added `raise_on_fail` per https://github.com/ApeWorX/ape/pull/957

### How to verify it

Added new test to verify

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
