### PR TITLE
test: test `get_receipt()`

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -29,6 +29,7 @@ from eth_utils import is_0x_prefixed, to_hex
 from evm_trace import CallTreeNode, CallType, TraceFrame, get_calltree_from_geth_trace
 from hexbytes import HexBytes
 from web3 import HTTPProvider, Web3
+from web3.eth import TxParams
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 
@@ -340,7 +341,8 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             txn_dict = txn.dict()
 
             try:
-                txn_hash = self._web3.eth.send_transaction(txn_dict)  # type: ignore
+                txn_params = cast(TxParams, txn_dict)
+                txn_hash = self.web3.eth.send_transaction(txn_params)
             except ValueError as err:
                 raise self.get_virtual_machine_error(err) from err
 

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -153,3 +153,12 @@ def test_transaction_unknown_contract_as_sender(accounts, networks, create_fork_
     multi_sig = accounts[account]
     multi_sig.transfer(accounts[0], "100 gwei")
     networks.active_provider = init_provider
+
+
+@pytest.mark.fork
+def test_get_receipt(connected_mainnet_fork_provider, fork_contract_instance, owner):
+    receipt = fork_contract_instance.setAddress(owner.address, sender=owner)
+    actual = connected_mainnet_fork_provider.get_receipt(receipt.txn_hash)
+    assert receipt.txn_hash == actual.txn_hash
+    assert actual.receiver == fork_contract_instance.address
+    assert actual.sender == receipt.sender

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -224,3 +224,11 @@ def test_set_account_balance(connected_provider, owner, convert, amount):
 def test_return_value(connected_provider, contract_instance, owner):
     receipt = contract_instance.setAddress(owner.address, sender=owner)
     assert receipt.return_value == 123
+
+
+def test_get_receipt(connected_provider, contract_instance, owner):
+    receipt = contract_instance.setAddress(owner.address, sender=owner)
+    actual = connected_provider.get_receipt(receipt.txn_hash)
+    assert receipt.txn_hash == actual.txn_hash
+    assert actual.receiver == contract_instance.address
+    assert actual.sender == receipt.sender


### PR DESCRIPTION
### What I did

Adds tests for `get_receipt()` because I am having issues with `receiver` missing sometimes and am trying to figure out why. No luck yet, but having these tests would help me rule those things out faster.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
