### PR TITLE
fix: update web3 isConnected()

### DIFF
--- a/ape_hardhat/providers.py
+++ b/ape_hardhat/providers.py
@@ -241,7 +241,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             return
 
         self._web3 = Web3(HTTPProvider(self.uri, request_kwargs={"timeout": self.timeout}))
-        if not self._web3.isConnected():
+        if not self._web3.is_connected():
             self._web3 = None
             return
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.5.0,<0.6",
+        "eth-ape>=0.5.2,<0.6",
         "evm-trace",  # Use same version as eth-ape
         "hexbytes",  # Use same version as eth-ape
         "web3",  # Use same version as eth-ape


### PR DESCRIPTION
This is needed as a companion to https://github.com/ApeWorX/ape/pull/1082 since the plugin uses ape's web3 dependency