### PR TITLE
test: add tracing pytester tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,18 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.982
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -262,9 +262,9 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         # Handle if using PoA Hardhat
 
-        def is_likely_poa() -> bool:
+        def began_poa() -> bool:
             try:
-                block = self.web3.eth.get_block("latest")
+                block = self.web3.eth.get_block(0)
             except ExtraDataLengthError:
                 return True
 
@@ -273,7 +273,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                 or len(block.get("extraData", "")) > MAX_EXTRADATA_LENGTH
             )
 
-        if is_likely_poa():
+        if began_poa():
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     def _start(self):
@@ -495,7 +495,20 @@ class HardhatForkProvider(HardhatProvider):
 
         # Verify that we're connected to a Hardhat node with mainnet-fork mode.
         self._upstream_provider.connect()
-        upstream_genesis_block_hash = self._upstream_provider.get_block(0).hash
+
+        try:
+            upstream_genesis_block_hash = self._upstream_provider.get_block(0).hash
+        except ExtraDataLengthError as err:
+            if isinstance(self._upstream_provider, Web3Provider):
+                logger.error(
+                    f"Upstream provider '{self._upstream_provider.name}' "
+                    f"missing Geth PoA middleware."
+                )
+                self._upstream_provider.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+                upstream_genesis_block_hash = self._upstream_provider.get_block(0).hash
+            else:
+                raise ProviderError(f"Unable to get genesis block: {err}.") from err
+
         self._upstream_provider.disconnect()
 
         if self.get_block(0).hash != upstream_genesis_block_hash:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
 [tool.mypy]
-exclude = "(build/)|(tests/functional/data)"
+exclude = ["build/", "tests/functional/data/"]
 
 [tool.setuptools_scm]
 write_to = "ape_hardhat/version.py"

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ extras_require = {
     "lint": [
         "black>=22.10.0",  # auto-formatter and linter
         "mypy>=0.982",  # Static type analyzer
-        "flake8>=5.0.4,<6",  # Style linter
-        "isort>=5.10.1,<6.0",  # Import sorting linter
+        "flake8>=5.0.4",  # Style linter
+        "isort>=5.10.1",  # Import sorting linter
         "types-requests",  # NOTE: Needed due to mypy typeshed
     ],
     "doc": [

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ extras_require = {
         "rich",  # Needed for trace tests
     ],
     "lint": [
-        "black>=22.6.0",  # auto-formatter and linter
-        "mypy>=0.971",  # Static type analyzer
-        "flake8>=4.0.1,<5.0",  # Style linter
+        "black>=22.10.0",  # auto-formatter and linter
+        "mypy>=0.982",  # Static type analyzer
+        "flake8>=5.0.4,<6",  # Style linter
         "isort>=5.10.1,<6.0",  # Import sorting linter
         "types-requests",  # NOTE: Needed due to mypy typeshed
     ],

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -17,3 +17,11 @@ hardhat:
       goerli:
         upstream_provider: alchemy
         block_number: 7849922
+
+test:
+  # Turn to `false` because running pytest within pytest.
+  disconnect_providers_after: false
+
+  gas:
+    exclude:
+      - method: setAdd*

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -19,9 +19,9 @@ hardhat:
         block_number: 7849922
 
 test:
-  # Turn to `false` because running pytest within pytest.
+  # `false` because running pytest within pytest.
   disconnect_providers_after: false
 
   gas:
     exclude:
-      - method: setAdd*
+      - method_name: setAdd*

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -16,4 +16,4 @@ hardhat:
         block_number: 15776634
       goerli:
         upstream_provider: alchemy
-        block_number: 3853585
+        block_number: 7849922

--- a/tests/data/python/pytest_tests.py
+++ b/tests/data/python/pytest_tests.py
@@ -1,6 +1,6 @@
 def test_provider(project, networks):
     """
-    Tests that the networks gets set from ape-config.yaml.
+    Tests that the network gets set from ape-config.yaml.
     """
     assert networks.provider.name == "hardhat"
 

--- a/tests/data/python/pytest_tests.py
+++ b/tests/data/python/pytest_tests.py
@@ -1,29 +1,42 @@
 def test_provider(project, networks):
-    # The default gets set in `ape-config.yaml`
+    """
+    Tests that the networks gets set from ape-config.yaml.
+    """
     assert networks.provider.name == "hardhat"
 
 
 def test_contract_interaction(owner, contract):
+    """
+    Traditional ape-test style test.
+    """
     contract.setNumber(123, sender=owner)
     assert contract.myNumber() == 123
 
 
 def test_transfer(accounts):
-    # Useful for seeing transfer gas
+    """
+    Tests that the ReceiptCapture handles transfer transactions.
+    """
     accounts[0].transfer(accounts[1], "100 gwei")
 
 
-def test_using_contract_with_same_name(owner, project):
+def test_using_contract_with_same_type_and_method_call(owner, project):
+    """
+    Deploy the same contract from the ``contract`` fixture and call a method
+    that gets called elsewhere in the test suite. This shows that we amass
+    results across all instances of contract types when making the gas report.
+    """
     contract = project.TestContractVy.deploy(sender=owner)
     contract.setNumber(123, sender=owner)
     assert contract.myNumber() == 123
 
 
 def test_two_contracts_with_same_symbol(owner, accounts, project):
-    # Tests against scenario when using 2 tokens with same symbol.
-    # There was almost a bug where the contract IDs clashed.
-    # This is to help prevent future bugs related to this.
-
+    """
+    Tests against scenario when using 2 tokens with same symbol.
+    There was almost a bug where the contract IDs clashed.
+    This is to help prevent future bugs related to this.
+    """
     receiver = accounts[1]
     token_a = project.TokenA.deploy(sender=owner)
     token_b = project.TokenB.deploy(sender=owner)
@@ -31,3 +44,21 @@ def test_two_contracts_with_same_symbol(owner, accounts, project):
     token_b.transfer(receiver, 6, sender=owner)
     assert token_a.balanceOf(receiver) == 5
     assert token_b.balanceOf(receiver) == 6
+
+
+def test_call_method_excluded_from_cli_options(owner, contract):
+    """
+    Call a method so that we can intentionally ignore it via command
+    line options and test that it does not show in the report.
+    """
+    receipt = contract.fooAndBar(sender=owner)
+    assert not receipt.failed
+
+
+def test_call_method_excluded_from_config(owner, contract):
+    """
+    Call a method excluded in the ``ape-config.yaml`` file
+    for asserting it does not show in gas report.
+    """
+    receipt = contract.setAddress(owner.address, sender=owner)
+    assert not receipt.failed

--- a/tests/expected_traces.py
+++ b/tests/expected_traces.py
@@ -517,13 +517,13 @@ DSProxy.execute\(_target=LoanShifterTaker, _data=0x35..0000\) -> '' \[1275643 ga
         \) \[174327 gas\]
 """
 LOCAL_GAS_REPORT = r"""
-                              contract_a.json Gas
+                              ContractA Gas
 
   Method                   Times called     Min.     Max.     Mean   Median
  ───────────────────────────────────────────────────────────────────────────
   methodWithoutArguments +1 +\d+ +\d+ +\d+ + \d+
 
-                         contract_b.json Gas
+                         ContractB Gas
 
   Method         Times called     Min.     Max.     Mean   Median
  ─────────────────────────────────────────────────────────────────
@@ -532,7 +532,7 @@ LOCAL_GAS_REPORT = r"""
   methodB2 +1 +\d+ +\d+ +\d+ + \d+
   bandPractice +1 +\d+ +\d+ +\d+ + \d+
 
-                        contract_c.json Gas
+                        ContractC Gas
 
   Method           Times called     Min.     Max.     Mean   Median
  ───────────────────────────────────────────────────────────────────

--- a/tests/test_trace_pytest.py
+++ b/tests/test_trace_pytest.py
@@ -38,3 +38,9 @@ def ape_pytester(project, pytester):
     pytester.makeconftest(CONFTEST)
     pytester.makepyfile(TEST_FILE)
     return pytester
+
+
+@pytest.mark.sync
+def test_gas_flag_in_tests(ape_pytester, project):
+    result = ape_pytester.runpytest("--gas", "-s")
+    result.assert_outcomes(passed=NUM_TESTS), "\n".join(result.outlines)

--- a/tests/test_trace_pytest.py
+++ b/tests/test_trace_pytest.py
@@ -6,30 +6,27 @@ BASE_DATA_PATH = Path(__file__).parent / "data" / "python"
 CONFTEST = (BASE_DATA_PATH / "pytest_test_conftest.py").read_text()
 TEST_FILE = (BASE_DATA_PATH / "pytest_tests.py").read_text()
 NUM_TESTS = len([x for x in TEST_FILE.split("\n") if x.startswith("def test_")])
-EXPECTED_GAS_REPORT = r"""
-                   vyper_contract.json Gas
+TOKEN_B_GAS_REPORT = r"""
+                         TokenB Gas
+
+  Method     Times called    Min.    Max.    Mean   Median
+ ──────────────────────────────────────────────────────────
+  transfer              1   50911   50911   50911    50911
+"""
+EXPECTED_GAS_REPORT = rf"""
+                     TestContractVy Gas
 
   Method      Times called    Min.    Max.    Mean   Median
  ───────────────────────────────────────────────────────────
   setNumber              3   51021   53821   51958    51033
+  fooAndBar              1   23430   23430   23430    23430
 
-                    Transferring ETH Gas
-
-  Method     Times called    Min.    Max.    Mean   Median
- ──────────────────────────────────────────────────────────
-  to:dev_1              1   21000   21000   21000    21000
-
-                      token_a.json Gas
+                         TokenA Gas
 
   Method     Times called    Min.    Max.    Mean   Median
  ──────────────────────────────────────────────────────────
   transfer              1   50911   50911   50911    50911
-
-                      token_b.json Gas
-
-  Method     Times called    Min.    Max.    Mean   Median
- ──────────────────────────────────────────────────────────
-  transfer              1   50911   50911   50911    50911
+{TOKEN_B_GAS_REPORT}
 """
 
 
@@ -40,7 +37,39 @@ def ape_pytester(project, pytester):
     return pytester
 
 
-@pytest.mark.sync
-def test_gas_flag_in_tests(ape_pytester, project):
-    result = ape_pytester.runpytest("--gas", "-s")
+def run_trace_test(result, expected_report: str = EXPECTED_GAS_REPORT):
     result.assert_outcomes(passed=NUM_TESTS), "\n".join(result.outlines)
+
+    gas_header_line_index = None
+    for index, line in enumerate(result.outlines):
+        if "Gas Profile" in line:
+            gas_header_line_index = index
+
+    assert gas_header_line_index is not None, "'Gas Profile' not in output."
+    expected = expected_report.split("\n")[1:]
+    start_index = gas_header_line_index + 1
+    end_index = start_index + len(expected)
+    actual = [x.rstrip() for x in result.outlines[start_index:end_index]]
+    assert len(actual) == len(expected)
+    for actual_line, expected_line in zip(actual, expected):
+        assert actual_line == expected_line
+
+
+@pytest.mark.sync
+def test_gas_flag_in_tests(ape_pytester):
+    result = ape_pytester.runpytest("--gas")
+    run_trace_test(result)
+
+
+@pytest.mark.sync
+def test_gas_flag_exclude_method_using_cli_option(ape_pytester):
+    line = "\n  fooAndBar              1   23430   23430   23430    23430"
+    expected = EXPECTED_GAS_REPORT.replace(line, "")
+    result = ape_pytester.runpytest("--gas", "--gas-exclude", "*:fooAndBar")
+    run_trace_test(result, expected_report=expected)
+
+
+@pytest.mark.sync
+def test_gas_flag_excluding_contracts(ape_pytester):
+    result = ape_pytester.runpytest("--gas", "--gas-exclude", "TestContractVy,TokenA")
+    run_trace_test(result, expected_report=TOKEN_B_GAS_REPORT)


### PR DESCRIPTION
### What I did

* Adds missing test that I thought I had added and fixes some thing there
* Adds new tests for the `--gas-exclude` flag and `ape: test: gas` config stuff you can do by ignoring contracts and methods and such.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
