### PR TITLE
perf: adds --no-deploy (when appropriate) to hardhat fork command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
         name: black
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
     -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.982
     hooks:
     -   id: mypy
-        additional_dependencies: [types-requests]
+        additional_dependencies: [types-PyYAML, types-requests]
 
 
 default_language_version:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.982
     hooks:
     -   id: mypy
-        additional_dependencies: [types-PyYAML, types-requests]
+        additional_dependencies: [types-PyYAML, types-requests, types-setuptools]
 
 
 default_language_version:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ hardhat:
 
 Otherwise, it defaults to the default mainnet provider plugin. You can also specify a ``block_number``.
 
-Hardhat deloyments are disabled for forks for performance reasons.  If you want your contract deployments you run on your fork, you can set ``no_deploy`` to ``False`` in your config.
+Hardhat deployments are disabled for forks for performance reasons.
+If you want your contract deployments to run on your fork, you can set ``no_deploy`` to ``False`` in your config:
 
 ```yaml
 hardhat:

--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ Otherwise, it defaults to the default mainnet provider plugin. You can also spec
 
 **NOTE**: Make sure you have the upstream provider plugin installed for ape.
 
-Hardhat deployments are disabled for forks for performance reasons.
-If you want your contract deployments to run on your fork, you can set ``no_deploy`` to ``False`` in your config:
+[Hardhat deployments](https://github.com/wighawag/hardhat-deploy#deploy-scripts-tags-and-dependencies) are disabled for forks for performance reasons. If you want your contract deployments to run on your fork, you can set ``no_deploy`` to ``False`` in your config:
 
 ```yaml
 hardhat:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ hardhat:
 
 Otherwise, it defaults to the default mainnet provider plugin. You can also specify a ``block_number``.
 
+Hardhat deloyments are disabled for forks for performance reasons.  If you want your contract deployments you run on your fork, you can set ``no_deploy`` to ``False`` in your config.
+
+```yaml
+hardhat:
+  fork:
+    ethereum:
+      mainnet:
+        upstream_provider: alchemy
+        no_deploy: false
+```
+
 **NOTE**: Make sure you have the upstream provider plugin installed for ape.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ hardhat:
 
 Otherwise, it defaults to the default mainnet provider plugin. You can also specify a ``block_number``.
 
+**NOTE**: Make sure you have the upstream provider plugin installed for ape.
+
 Hardhat deployments are disabled for forks for performance reasons.
 If you want your contract deployments to run on your fork, you can set ``no_deploy`` to ``False`` in your config:
 
@@ -95,8 +97,6 @@ hardhat:
         upstream_provider: alchemy
         no_deploy: false
 ```
-
-**NOTE**: Make sure you have the upstream provider plugin installed for ape.
 
 ```bash
 ape plugins install alchemy

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Otherwise, it defaults to the default mainnet provider plugin. You can also spec
 
 **NOTE**: Make sure you have the upstream provider plugin installed for ape.
 
-[Hardhat deployments](https://github.com/wighawag/hardhat-deploy#deploy-scripts-tags-and-dependencies) are disabled for forks for performance reasons. If you want your contract deployments to run on your fork, you can set ``no_deploy`` to ``False`` in your config:
+[Hardhat deployments](https://github.com/wighawag/hardhat-deploy#deploy-scripts-tags-and-dependencies) are disabled for forks for performance reasons. If you want your contract deployments to run on your fork, you can set ``enable_hardhat_deployments`` to ``true`` in your config:
 
 ```yaml
 hardhat:
@@ -94,7 +94,7 @@ hardhat:
     ethereum:
       mainnet:
         upstream_provider: alchemy
-        no_deploy: false
+        enable_hardhat_deployments: true
 ```
 
 ```bash

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -157,7 +157,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
     @property
     def timeout(self) -> int:
-        return self.config.request_timeout  # type: ignore
+        return self.config.request_timeout
 
     @property
     def chain_id(self) -> int:
@@ -247,7 +247,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         # NOTE: Must set port before calling 'super().connect()'.
         if not self.port:
-            self.port = self.config.port  # type: ignore
+            self.port = self.config.port
 
         if self.is_connected:
             # Connects to already running process
@@ -266,7 +266,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                         f"Connecting to existing '{self.process_name}' at port '{self.port}'."
                     )
             else:
-                for _ in range(self.config.process_attempts):  # type: ignore
+                for _ in range(self.config.process_attempts):
                     try:
                         self._start()
                         break
@@ -515,7 +515,7 @@ class HardhatForkProvider(HardhatProvider):
 
     @property
     def timeout(self) -> int:
-        return self.config.fork_request_timeout  # type: ignore
+        return self.config.fork_request_timeout
 
     @property
     def _upstream_network_name(self) -> str:

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -114,7 +114,7 @@ class PackageJson(BaseModel):
 class HardhatForkConfig(PluginConfig):
     upstream_provider: Optional[str] = None
     block_number: Optional[int] = None
-    no_deploy: bool = True
+    enable_hardhat_deployments: bool = False
 
 
 class HardhatNetworkConfig(PluginConfig):
@@ -511,8 +511,8 @@ class HardhatForkProvider(HardhatProvider):
         return self._fork_config.block_number
 
     @property
-    def no_deploy(self) -> bool:
-        return self._fork_config.no_deploy
+    def enable_hardhat_deployments(self) -> bool:
+        return self._fork_config.enable_hardhat_deployments
 
     @property
     def timeout(self) -> int:
@@ -583,7 +583,7 @@ class HardhatForkProvider(HardhatProvider):
         cmd.extend(("--fork", self.fork_url))
 
         # --no-deploy option is only available if hardhat-deploy is installed
-        if self.no_deploy and self._has_hardhat_plugin("hardhat-deploy"):
+        if not self.enable_hardhat_deployments and self._has_hardhat_plugin("hardhat-deploy"):
             cmd.append("--no-deploy")
         if self.fork_block_number is not None:
             cmd.extend(("--fork-block-number", str(self.fork_block_number)))

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -107,7 +107,7 @@ class PackageJson(BaseModel):
     version: Optional[str]
     description: Optional[str]
     dependencies: Optional[Dict[str, str]]
-    devDependencies: Optional[Dict[str, str]]
+    dev_dependencies: Optional[Dict[str, str]] = Field(None, alias="devDependencies")
 
 
 class HardhatForkConfig(PluginConfig):

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -64,6 +64,7 @@ module.exports = {{
 }};
 """
 HARDHAT_CONFIG_FILE_NAME = "hardhat.config.js"
+HARDHAT_PLUGIN_PATTERN = re.compile(r"hardhat-[A-Za-z0-9-]+$")
 _NO_REASON_REVERT_MESSAGE = "Transaction reverted without a reason string"
 _REVERT_REASON_PREFIX = (
     "Error: VM Exception while processing transaction: reverted with reason string "
@@ -224,7 +225,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         plugins: List[str] = []
 
         def package_is_plugin(package: str) -> bool:
-            return re.search(r"hardhat-[A-Za-z0-9-]+$", package) is not None
+            return re.search(HARDHAT_PLUGIN_PATTERN, package) is not None
 
         if self._package_json.dependencies:
             plugins.extend(filter(package_is_plugin, self._package_json.dependencies.keys()))

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -1,4 +1,3 @@
-import json
 import random
 import re
 import shutil
@@ -108,7 +107,7 @@ class PackageJson(BaseModel):
     version: Optional[str]
     description: Optional[str]
     dependencies: Optional[Dict[str, str]]
-    dev_dependencies: Optional[Dict[str, str]] = Field(None, alias="devDependencies")
+    dev_dependencies: Optional[Dict[str, str]] = Field(alias="devDependencies")
 
 
 class HardhatForkConfig(PluginConfig):
@@ -218,7 +217,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if not json_path.is_file():
             return PackageJson()
 
-        return PackageJson(**json.loads(json_path.read_text()))
+        return PackageJson.parse_file(json_path)
 
     @cached_property
     def _hardhat_plugins(self) -> List[str]:

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -30,7 +30,7 @@ from ape_test import Config as TestConfig
 from eth_utils import is_0x_prefixed, is_hex, to_hex
 from evm_trace import CallTreeNode, CallType, TraceFrame, get_calltree_from_geth_trace
 from hexbytes import HexBytes
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from web3 import HTTPProvider, Web3
 from web3.eth import TxParams
 from web3.exceptions import ExtraDataLengthError
@@ -230,8 +230,8 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if self._package_json.dependencies:
             plugins.extend(filter(package_is_plugin, self._package_json.dependencies.keys()))
 
-        if self._package_json.devDependencies:
-            plugins.extend(filter(package_is_plugin, self._package_json.devDependencies.keys()))
+        if self._package_json.dev_dependencies:
+            plugins.extend(filter(package_is_plugin, self._package_json.dev_dependencies.keys()))
 
         return plugins
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import os.path
 
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
@@ -17,6 +17,7 @@ extras_require = {
     "lint": [
         "black>=22.10.0",  # auto-formatter and linter
         "mypy==0.982",  # Static type analyzer
+        "types-setuptools",  # Needed for mypy typeshed.
         "flake8>=5.0.4",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
         "types-requests",  # NOTE: Needed due to mypy typeshed

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ extras_require = {
     "lint": [
         "black>=22.10.0",  # auto-formatter and linter
         "mypy==0.982",  # Static type analyzer
-        "types-setuptools",  # Needed for mypy typeshed.
+        "types-PyYAML",  # Needed due to mypy typeshed
+        "types-setuptools",  # Needed for mypy typeshed
         "flake8>=5.0.4",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
         "types-requests",  # NOTE: Needed due to mypy typeshed

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -50,7 +50,7 @@ def test_impersonate(networks, accounts, upstream_network, port, create_fork_pro
 def test_request_timeout(networks, config, create_fork_provider):
     provider = create_fork_provider(9008)
     provider.connect()
-    actual = provider.web3.provider._request_kwargs["timeout"]  # type: ignore
+    actual = provider.web3.provider._request_kwargs["timeout"]
     expected = 360  # Value set in `ape-config.yaml`
     assert actual == expected
     provider.disconnect()

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -160,14 +160,14 @@ def test_get_receipt(connected_mainnet_fork_provider, fork_contract_instance, ow
 
 @pytest.mark.sync
 @pytest.mark.parametrize(
-    "upstream_network,port,no_deploy,fork_block_number,has_hardhat_deploy",
+    "upstream_network,port,enable_hardhat_deployments,fork_block_number,has_hardhat_deploy",
     [
-        ("mainnet", 8994, True, 15_964_699, False),
-        ("mainnet", 8995, True, 15_932_345, True),
-        ("mainnet", 8996, False, 15_900_000, False),
-        ("goerli", 8997, True, 7_948_861, False),
-        ("goerli", 8998, True, 7_424_430, True),
-        ("goerli", 8999, False, 7_900_000, False),
+        ("mainnet", 8994, False, 15_964_699, False),
+        ("mainnet", 8995, False, 15_932_345, True),
+        ("mainnet", 8996, True, 15_900_000, False),
+        ("goerli", 8997, False, 7_948_861, False),
+        ("goerli", 8998, False, 7_424_430, True),
+        ("goerli", 8999, True, 7_900_000, False),
     ],
 )
 def test_hardhat_command(
@@ -176,7 +176,7 @@ def test_hardhat_command(
     create_fork_provider,
     port,
     upstream_network,
-    no_deploy,
+    enable_hardhat_deployments,
     fork_block_number,
     has_hardhat_deploy,
 ):
@@ -185,7 +185,7 @@ def test_hardhat_command(
             "fork": {
                 "ethereum": {
                     upstream_network: {
-                        "no_deploy": no_deploy,
+                        "enable_hardhat_deployments": enable_hardhat_deployments,
                         "block_number": fork_block_number,
                     }
                 }
@@ -223,7 +223,7 @@ def test_hardhat_command(
             "--fork",
             provider.fork_url,
         ]
-        if no_deploy and has_hardhat_deploy:
+        if not enable_hardhat_deployments and has_hardhat_deploy:
             expected_cmd.append("--no-deploy")
         if fork_block_number:
             expected_cmd.extend(("--fork-block-number", str(fork_block_number)))

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -173,7 +173,7 @@ def test_get_call_tree(connected_provider, sender, receiver):
 
 
 def test_request_timeout(connected_provider, config, create_provider):
-    actual = connected_provider.web3.provider._request_kwargs["timeout"]  # type: ignore
+    actual = connected_provider.web3.provider._request_kwargs["timeout"]
     expected = 29  # Value set in `ape-config.yaml`
     assert actual == expected
 


### PR DESCRIPTION
### What I did

Updated `HardhatForkProvider` to use `--no-deploy` when running `hardhat node --fork [...]` when the `hardhat-deploy` plugin is installed to prevent contract deployments from being automatically run.  

### How I did it

- `HardhatProvider` now loads `package.json` and reads the installed Hardhat plugins (assuming `hardhat-` package prefixes)
- If `enable_hardhat_deployments` is not set (or set to false), and the `hardhat-deploy` plugin is installed, it will add `--no-deploy` option to the `hardhat node [...]`

### How to verify it

```bash
pytest
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
