### PR TITLE
fix: correct import statement of we3 TxParams [APE-764]

### DIFF
--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -287,7 +287,9 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         # Verify is actually a Hardhat provider,
         # or else skip it to possibly try another port.
         # TODO: Once we are on web3.py 0.6.0b8 or later, can just use snake_case here.
-        client_version = getattr(self._web3, "client_version", getattr(self._web3, "clientVersion"))
+        client_version = getattr(
+            self._web3, "client_version", getattr(self._web3, "clientVersion", None)
+        )
 
         if "hardhat" in client_version.lower():
             self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -33,11 +33,11 @@ from evm_trace import get_calltree_from_geth_trace
 from hexbytes import HexBytes
 from pydantic import BaseModel, Field
 from web3 import HTTPProvider, Web3
-from web3.eth import TxParams
 from web3.exceptions import ExtraDataLengthError
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 from web3.middleware.validation import MAX_EXTRADATA_LENGTH
+from web3.types import TxParams
 
 from .exceptions import HardhatNotInstalledError, HardhatProviderError, HardhatSubprocessError
 


### PR DESCRIPTION
### What I did

fix import, helps upgrade to 6.0 but can merge whenever
we should have importing this way all along, so not really a breaking change

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
