### PR TITLE
chore: delete unneeded code from web3.py 6 upgrade [APE-765]

### DIFF
--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -286,12 +286,8 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
 
         # Verify is actually a Hardhat provider,
         # or else skip it to possibly try another port.
-        # TODO: Once we are on web3.py 0.6.0b8 or later, can just use snake_case here.
-        client_version = getattr(
-            self._web3, "client_version", getattr(self._web3, "clientVersion", None)
-        )
-
-        if "hardhat" in client_version.lower():
+        client_version = self._web3.client_version.lower()
+        if "hardhat" in client_version:
             self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)
         else:
             raise ProviderError(

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.5,<0.7",
+        "eth-ape>=0.6.7,<0.7",
         "evm-trace",  # Use same version as eth-ape
         "hexbytes",  # Use same version as eth-ape
         "web3",  # Use same version as eth-ape


### PR DESCRIPTION
### What I did

we had this check in before to handle both but now we can just handle web3.py >= 6.0.0

must wait for after https://github.com/ApeWorX/ape/pull/1361

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
