### PR TITLE
Added bsc plugin as another possible fork network

### DIFF
--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -38,7 +38,10 @@ def providers():
     yield "optimism", LOCAL_NETWORK_NAME, HardhatProvider
     yield "optimism", "mainnet-fork", HardhatForkProvider
     yield "optimism", "goerli-fork", HardhatForkProvider
-
+    
+    yield "bsc", LOCAL_NETWORK_NAME, HardhatProvider
+    yield "bsc", "mainnet-fork", HardhatProvider
+    yield "bsc", "testnet-fork", HardhatProvider
 
 __all__ = [
     "HardhatNetworkConfig",


### PR DESCRIPTION
Needed bsc added to the list, this change came from the recommendation of fubuloubu in Discord.

### What I did

fixes: #Added BSC to the list of network plugins

### How I did it
Haven't tested it, will download and update later

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
