### PR TITLE
test: ensure can use impersonated account

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,8 +120,7 @@ def contract_type(request, get_contract_type) -> ContractType:
 def get_contract_type():
     def fn(name: str):
         path = BASE_CONTRACTS_PATH / "ethereum" / "local" / f"{name}.json"
-        content = path.read_text()
-        return ContractType.parse_raw(content)
+        return ContractType.parse_file(path)
 
     return fn
 
@@ -223,3 +222,15 @@ def temp_config(config):
             config._cached_configs = {}
 
     return func
+
+
+@pytest.fixture
+def contract_a(owner, connected_provider, get_contract_type):
+    contract_c = owner.deploy(ContractContainer(get_contract_type("contract_c")))
+    contract_b = owner.deploy(
+        ContractContainer(get_contract_type("contract_b")), contract_c.address
+    )
+    contract_a = owner.deploy(
+        ContractContainer(get_contract_type("contract_a")), contract_b.address, contract_c.address
+    )
+    return contract_a

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -106,9 +106,14 @@ def test_snapshot_and_revert(connected_provider):
     assert block_1.hash == block_3.hash
 
 
-def test_unlock_account(connected_provider):
+def test_unlock_account(connected_provider, owner, contract_a):
     assert connected_provider.unlock_account(TEST_WALLET_ADDRESS) is True
     assert TEST_WALLET_ADDRESS in connected_provider.unlocked_accounts
+
+    # Ensure can transact.
+    impersonated_account = connected_provider.account_manager[TEST_WALLET_ADDRESS]
+    receipt = contract_a.methodWithoutArguments(sender=impersonated_account)
+    assert not receipt.failed
 
 
 def test_get_transaction_trace(connected_provider, sender, receiver):

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from ape.contracts import ContractContainer
-from ethpm_types import ContractType
 
 from .expected_traces import (
     LOCAL_GAS_REPORT,
@@ -53,22 +51,6 @@ def full_contracts_cache(config):
 )
 def mainnet_receipt(request, mainnet_fork_provider):
     return mainnet_fork_provider.get_receipt(request.param)
-
-
-@pytest.fixture
-def contract_a(owner, connected_provider):
-    base_path = BASE_CONTRACTS_PATH / "local"
-
-    def get_contract_type(suffix: str) -> ContractType:
-        return ContractType.parse_file(base_path / f"contract_{suffix}.json")
-
-    contract_c = owner.deploy(ContractContainer(get_contract_type("c")))
-    contract_b = owner.deploy(ContractContainer(get_contract_type("b")), contract_c.address)
-    contract_a = owner.deploy(
-        ContractContainer(get_contract_type("a")), contract_b.address, contract_c.address
-    )
-
-    return contract_a
 
 
 @pytest.fixture


### PR DESCRIPTION
### What I did

I am debugging something in `ape-foundry` but needed to compare with `ape-hardhat` but struggling to find a good test.
This PR makes a good test template that I can use both.

### How I did it

* move contract_a to conftest
* use impersonated account in test to ensure can call method from that contract

### How to verify it

tests all pass will suffice.
no need prod code changes.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
