### PR TITLE
fix: issue where wouldn't show correct not-installed error [APE-918]

### DIFF
--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -236,7 +236,6 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         if not hardhat_version or not hardhat_version[0].isnumeric():
             raise HardhatNotInstalledError()
 
-        # This next check actually ensures it is installed.
         npm = shutil.which("npm")
         if not npm:
             raise HardhatSubprocessError(f"Could not locate `npm` executable. {suffix}")
@@ -248,6 +247,8 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             return npx
 
         data = json.loads(install_result)
+
+        # This actually ensures it is installed.
         self._detected_correct_install = "hardhat" in data.get("dependencies", {})
         return npx
 

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -187,6 +187,7 @@ def test_hardhat_command(
     fork_block_number,
     has_hardhat_deploy,
     name,
+    data_folder,
 ):
     eth_config = {
         name: {
@@ -204,7 +205,7 @@ def test_hardhat_command(
         "name": "contracts",
         "version": "0.1.0",
         "dependencies": {
-            "hardhat": "^2.6.4",
+            "hardhat": "^2.13.1",
             "hardhat-ethers": "^2.0.2",
         },
     }
@@ -222,24 +223,26 @@ def test_hardhat_command(
             provider_settings={},
         )
         provider.port = port
-        cmd = " ".join(provider.build_command())
-        expected_cmd = [
-            provider.npx_bin,
+        actual = provider.build_command()
+        expected = [
             name,
             "node",
             "--hostname",
             "127.0.0.1",
             "--port",
             str(port),
+            "--config",
+            str(data_folder / "hardhat" / "hardhat.config.js"),
             "--fork",
             provider.fork_url,
         ]
         if not enable_hardhat_deployments and has_hardhat_deploy:
-            expected_cmd.append("--no-deploy")
+            expected.append("--no-deploy")
         if fork_block_number:
-            expected_cmd.extend(("--fork-block-number", str(fork_block_number)))
+            expected.extend(("--fork-block-number", str(fork_block_number)))
 
-        assert cmd == " ".join(expected_cmd)
+        assert actual[0].endswith("npx")
+        assert actual[1:] == expected
 
 
 @pytest.mark.fork


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #141 
Fixes: APE-910

### How I did it

* Track if seemingly not installed right
* If times out and was not installed right, show custom error

The reason I made it still attempt is because there are situations where it will still work, such as when using subprocess stuff.

### How to verify it

* Go to a project where Hardhat is not yet installed.
* Do `ape console --network etheruem:local:hardhat
* Wait for it to fail
* Notice the custom error.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
