### PR TITLE
fix: allow getting traces when sender is impersonated [APE-971]

### DIFF
--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -30,6 +30,7 @@ from ape.types import AddressType, CallTreeNode, ContractCode, SnapshotID, Trace
 from ape.utils import cached_property
 from ape_test import Config as TestConfig
 from chompjs import parse_js_object  # type: ignore
+from eth_typing import HexStr
 from eth_utils import is_0x_prefixed, is_hex, to_hex
 from evm_trace import CallType
 from evm_trace import TraceFrame as EvmTraceFrame
@@ -496,20 +497,62 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                 txn_dict["type"] = HexBytes(txn_dict["type"]).hex()
 
             txn_params = cast(TxParams, txn_dict)
-
             try:
                 txn_hash = self.web3.eth.send_transaction(txn_params)
             except ValueError as err:
-                raise self.get_virtual_machine_error(err) from err
+                breakpoint()
+                err_args = getattr(err, "args", None)
+                tx: Union[TransactionAPI, ReceiptAPI]
+                if (
+                    err_args is not None
+                    and isinstance(err_args[0], dict)
+                    and "data" in err_args[0]
+                    and "txHash" in err_args[0]["data"]
+                ):
+                    # Txn hash won't work in Ape at this point, but at least
+                    # we have it here. Use the receipt instead of the txn
+                    # for the err, so we can do source tracing.
+                    txn_hash_from_err = err_args[0]["data"]["txHash"]
+                    o
+
+                else:
+                    tx = txn
+
+                raise self.get_virtual_machine_error(err, txn=tx) from err
 
             receipt = self.get_receipt(
-                txn_hash.hex(), required_confirmations=txn.required_confirmations or 0
+                txn_hash.hex(), required_confirmations=txn.required_confirmations or 0, txn=txn_dict
             )
             receipt.raise_for_status()
 
         else:
             receipt = super().send_transaction(txn)
 
+        return receipt
+
+    def get_receipt(
+        self,
+        txn_hash: str,
+        required_confirmations: int = 0,
+        timeout: Optional[int] = None,
+        **kwargs,
+    ) -> ReceiptAPI:
+        try:
+            # Try once without waiting first.
+            # NOTE: This is required for txn sent with an impersonated account.
+            receipt_data = dict(self.web3.eth.get_transaction_receipt(HexStr(txn_hash)))
+        except Exception:
+            return super().get_receipt(
+                txn_hash, required_confirmations=required_confirmations, timeout=timeout
+            )
+
+        txn = kwargs.get("txn", dict(self.web3.eth.get_transaction(HexStr(txn_hash))))
+        data: Dict = {"txn_hash": txn_hash, **receipt_data, **txn}
+        if "gas_price" not in data:
+            data["gas_price"] = self.gas_price
+
+        receipt = self.network.ecosystem.decode_receipt(data)
+        self.chain_manager.history.append(receipt)
         return receipt
 
     def get_transaction_trace(self, txn_hash: str) -> Iterator[TraceFrame]:

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -500,7 +500,6 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
             try:
                 txn_hash = self.web3.eth.send_transaction(txn_params)
             except ValueError as err:
-                breakpoint()
                 err_args = getattr(err, "args", None)
                 tx: Union[TransactionAPI, ReceiptAPI]
                 if (
@@ -513,7 +512,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
                     # we have it here. Use the receipt instead of the txn
                     # for the err, so we can do source tracing.
                     txn_hash_from_err = err_args[0]["data"]["txHash"]
-                    o
+                    tx = self.get_receipt(txn_hash_from_err)
 
                 else:
                     tx = txn

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -119,6 +119,9 @@ def test_unlock_account(connected_provider, owner, contract_a, accounts):
     receipt = contract_a.methodWithoutArguments(sender=impersonated_account)
     assert not receipt.failed
 
+    txn_hash = receipt.transaction.txn_hash.hex()
+    assert receipt.txn_hash == txn_hash
+
 
 def test_get_transaction_trace(connected_provider, sender, receiver):
     transfer = sender.transfer(receiver, 1)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -119,9 +119,6 @@ def test_unlock_account(connected_provider, owner, contract_a, accounts):
     receipt = contract_a.methodWithoutArguments(sender=impersonated_account)
     assert not receipt.failed
 
-    txn_hash = receipt.transaction.txn_hash.hex()
-    assert receipt.txn_hash == txn_hash
-
 
 def test_get_transaction_trace(connected_provider, sender, receiver):
     transfer = sender.transfer(receiver, 1)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -240,6 +240,16 @@ def test_revert_error(error_contract, not_owner):
         error_contract.withdraw(sender=not_owner)
 
 
+def test_revert_error_from_impersonated_account(error_contract, accounts):
+    account = accounts[TEST_WALLET_ADDRESS]
+    with pytest.raises(error_contract.Unauthorized) as err:
+        error_contract.withdraw(sender=account)
+
+    # Before, this would fail because there would not be an associated txn
+    # because the account is impersonated.
+    assert err.value.txn.txn_hash.startswith("0x")
+
+
 def test_use_different_config(temp_config, networks):
     data = {"hardhat": {"hardhat_config_file": "./hardhat.config.ts"}}
     with temp_config(data):


### PR DESCRIPTION
### What I did

Fixed critical issue preventing any trace related feature from working when the sender was impersonated.
note you may need to use my ape-vyper and ape coverage PRs to properly test that because of other unrelated fixes currently only present there

### How I did it

* get tx hash from the error message
* attempt calling eth_getTransactionReceipt before super() which will do the waiting unnecessarily and the waiting for some reason never ends no matter what, no matter required confs are or timeout or anything... so whatever, have to bypass it i guess tho maybe im just doing something stupid
* finally, use that receipt as the `txn=` kwarg when crafting the vm error (which thankfully is allowed and welcomed in core ape framework).

now all the tracing stuff should work.
it was a pain tho and i dont like impersonated accounts (tho i understand they are sometimes required).

### How to verify it

cause a txn to fail uncaught where the sender is impersonated
watch the magic unfold

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
