### PR TITLE
feat: allow to work with Solidity compiler enrichment [APE-995]

### DIFF
--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -275,3 +275,11 @@ def test_connect_when_hardhat_not_installed(networks, mock_web3, install_detecti
     )
     with pytest.raises(HardhatNotInstalledError, match=expected):
         provider.connect()
+
+
+def test_get_virtual_machine_error_when_sol_panic(connected_provider):
+    msg = "Error: VM Exception while processing transaction: reverted with panic code 0x1"
+    err = ValueError(msg)
+    actual = connected_provider.get_virtual_machine_error(err)
+    expected = "0x1"
+    assert actual.revert_message == expected


### PR DESCRIPTION
### What I did

when using hardhat, the panic code can be extracted from the vm err but it is a bit branded (no prefix and other stuff around it etc).

this change allows it to work with ape-solidity for enrichment
have to use this PR tho: https://github.com/ApeWorX/ape-solidity/pull/99

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
