### PR TITLE
feat: handle CREATE in call traces [APE-1105]

### DIFF
--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -666,15 +666,24 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         # (21_000 + 4 gas per 0-byte and 16 gas per non-zero byte).
         data_gas = sum([4 if x == 0 else 16 for x in receipt.data])
         method_gas_cost = receipt.gas_used - 21_000 - data_gas
+        if receipt.contract_address:
+            # Is a deploy
+            address = receipt.contract_address
+            call_type = CallType.CREATE
+
+        else:
+            # Is an invoke
+            address = receipt.receiver
+            call_type = CallType.CALL
 
         evm_call = get_calltree_from_geth_trace(
             self._get_transaction_trace(txn_hash),
             gas_cost=method_gas_cost,
             gas_limit=receipt.gas_limit,
-            address=receipt.receiver,
+            address=address,
             calldata=receipt.data,
             value=receipt.value,
-            call_type=CallType.CALL,
+            call_type=call_type,
             failed=receipt.failed,
         )
         return self._create_call_tree_node(evm_call, txn_hash=txn_hash)

--- a/tests/test_gas_report.py
+++ b/tests/test_gas_report.py
@@ -13,6 +13,7 @@ TOKEN_B_GAS_REPORT = r"""
 
   Method +Times called +Min. +Max. +Mean +Median
  ─+
+  __init__ +\d +\d+ + \d+ + \d+ + \d+
   balanceOf +\d +\d+ + \d+ + \d+ + \d+
   transfer +\d +\d+ + \d+ + \d+ + \d+
 """
@@ -21,6 +22,7 @@ EXPECTED_GAS_REPORT = rf"""
 
   Method +Times called +Min. +Max. +Mean +Median
  ─+
+  __init__ +\d +\d+ + \d+ + \d+ + \d+
   fooAndBar +\d +\d+ + \d+ + \d+ + \d+
   myNumber +\d +\d+ + \d+ + \d+ + \d+
   setNumber +\d +\d+ + \d+ + \d+ + \d+
@@ -29,6 +31,7 @@ EXPECTED_GAS_REPORT = rf"""
 
   Method +Times called +Min. +Max. +Mean +Median
  ─+
+  __init__ +\d +\d+ + \d+ + \d+ + \d+
   balanceOf +\d +\d+ + \d+ + \d+ + \d+
   transfer +\d +\d+ + \d+ + \d+ + \d+
 {TOKEN_B_GAS_REPORT}

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -139,6 +139,19 @@ def test_get_call_tree(connected_provider, sender, receiver):
     assert repr(call_tree) == "0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7.0x()"
 
 
+def test_get_call_tree_deploy(connected_provider, contract_a):
+    txn_hash = contract_a.txn_hash
+    actual = connected_provider.get_call_tree(txn_hash)
+    assert repr(actual) == f"{contract_a.address}.__new__ [1265410 gas]"
+
+    # Show the enriched version.
+    expected = (
+        f"{contract_a.contract_type.name}.__new__(addrb=ContractB, addrc=ContractC) [1265410 gas]"
+    )
+    actual.enrich()
+    assert repr(actual) == expected
+
+
 def test_request_timeout(connected_provider, config):
     # Test value set in `ape-config.yaml`
     expected = 29


### PR DESCRIPTION
### What I did

Uses CREATE type call for deploys
 as well as sets the contract address as the target

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
