### PR TITLE
feat: increment function hit count for call coverage [APE-1122]

### DIFF
--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -718,6 +718,7 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         else:
             # Not sure if this is possible.
             address = None
+            call_type = None
 
         address = receipt.receiver or receipt.contract_address
         evm_call = get_calltree_from_geth_trace(

--- a/ape_hardhat/provider.py
+++ b/ape_hardhat/provider.py
@@ -577,6 +577,44 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
     def unlock_account(self, address: AddressType) -> bool:
         return self._make_request("hardhat_impersonateAccount", [address])
 
+    def send_call(self, txn: TransactionAPI, **kwargs) -> bytes:
+        result = super().send_call(txn, **kwargs)
+
+        # Hardhat does not support call tracing yet.
+        # But we are still able to incremenet func hits.
+        self._increment_call_func_coverage_hit_count(txn)
+
+        return result
+
+    def _increment_call_func_coverage_hit_count(self, txn: TransactionAPI):
+        """
+        A helper method for increment a method call function hit count in a
+        non-orthodox way. This is because Hardhat does support call traces yet.
+        """
+        if (
+            not txn.receiver
+            or not self._test_runner
+            or not self._test_runner.config_wrapper.track_coverage
+        ):
+            return
+
+        cov_data = self._test_runner.coverage_tracker.data
+        if not cov_data:
+            return
+
+        contract_type = self.chain_manager.contracts.get(txn.receiver)
+        if not contract_type:
+            return
+
+        contract_src = self.project_manager._create_contract_source(contract_type)
+        if not contract_src:
+            return
+
+        method_id = txn.data[:4]
+        if method_id in contract_type.view_methods:
+            method = contract_type.methods[method_id]
+            self._test_runner.coverage_tracker.hit_function(contract_src, method)
+
     def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
         """
         Creates a new message call transaction or a contract creation
@@ -670,12 +708,12 @@ class HardhatProvider(SubprocessProvider, Web3Provider, TestProviderAPI):
         # (21_000 + 4 gas per 0-byte and 16 gas per non-zero byte).
         data_gas = sum([4 if x == 0 else 16 for x in receipt.data])
         method_gas_cost = receipt.gas_used - 21_000 - data_gas
-
+        address = receipt.receiver or receipt.contract_address
         evm_call = get_calltree_from_geth_trace(
             self._get_transaction_trace(txn_hash),
             gas_cost=method_gas_cost,
             gas_limit=receipt.gas_limit,
-            address=receipt.receiver,
+            address=address,
             calldata=receipt.data,
             value=receipt.value,
             call_type=CallType.CALL,

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     url="https://github.com/ApeWorX/ape-hardhat",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.11,<0.7",
+        "eth-ape>=0.6.12,<0.7",
         "evm-trace",  # Use same version as eth-ape
         "hexbytes",  # Use same version as eth-ape
         "web3",  # Use same version as eth-ape

--- a/tests/test_gas_report.py
+++ b/tests/test_gas_report.py
@@ -13,6 +13,7 @@ TOKEN_B_GAS_REPORT = r"""
 
   Method +Times called +Min. +Max. +Mean +Median
  ─+
+  __init__ +\d +\d+ + \d+ + \d+ + \d+
   balanceOf +\d +\d+ + \d+ + \d+ + \d+
   transfer +\d +\d+ + \d+ + \d+ + \d+
 """
@@ -21,6 +22,7 @@ EXPECTED_GAS_REPORT = rf"""
 
   Method +Times called +Min. +Max. +Mean +Median
  ─+
+  __init__ +\d +\d+ + \d+ + \d+ + \d+
   fooAndBar +\d +\d+ + \d+ + \d+ + \d+
   myNumber +\d +\d+ + \d+ + \d+ + \d+
   setNumber +\d +\d+ + \d+ + \d+ + \d+
@@ -29,6 +31,7 @@ EXPECTED_GAS_REPORT = rf"""
 
   Method +Times called +Min. +Max. +Mean +Median
  ─+
+  __init__ +\d +\d+ + \d+ + \d+ + \d+
   balanceOf +\d +\d+ + \d+ + \d+ + \d+
   transfer +\d +\d+ + \d+ + \d+ + \d+
 {TOKEN_B_GAS_REPORT}


### PR DESCRIPTION
### What I did

hardhat doesnt offer a way to trace calls. however, we can still track func hit counts. this is great because auto-getters dont have source lines anyway. therefore, we can still get those counted in the coverage report.

tests needed

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
