### PR TITLE
fix: issue causing entire plugin to no longer function [APE-1207]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 import subprocess
 import tempfile
 from contextlib import contextmanager
@@ -282,3 +283,15 @@ def install_detection_fail(mocker):
     check_output_mock = mocker.patch("ape_hardhat.provider.check_output")
     check_output_mock.side_effect = side_effect
     return check_output_mock
+
+
+@pytest.fixture
+def no_hardhat_bin(project):
+    bin_path = project.path / "node_modules" / ".bin" / "hardhat"
+    bin_copy = project.path / "node_modules" / ".bin" / "hardhat-2"
+    shutil.move(bin_path, bin_copy)
+
+    try:
+        yield
+    finally:
+        shutil.move(bin_copy, bin_path)


### PR DESCRIPTION
### What I did

im not sure how this never raised before, but it is now...
plugin is unusable because the auto-generated config causes configuration errors in hardhat and the node never launches.
they must have added more validation recently or something, because really not sure how this went unnoticed, the tests wouldnt even pass. no node would start.

additionally, fixed other things we found in foundry related to remote host connections

### How I did it

put config in right spot

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
