### PR TITLE
test(ci): updates CI tests to use node v18 to match hardhat requirements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,7 +75,7 @@ jobs:
         - name: Setup Node
           uses: actions/setup-node@v3
           with:
-              node-version: '16'
+              node-version: '18'
 
         - name: Install Node Dependencies
           run: pushd tests && npm install --save-dev hardhat && popd


### PR DESCRIPTION
### What I did

Updates node version in CI to match minimum supported by hardhat.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
