### PR TITLE
fix(devops): update release-drafter to v6

### DIFF
--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -4,13 +4,14 @@ on:
   push:
     branches:
       - main
+      - fix/drafter # TODO: DELETEME
 
 jobs:
   update-draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v6
         with:
           disable-autolabeler: true
         env:

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/drafter # TODO: DELETEME
 
 jobs:
   update-draft:


### PR DESCRIPTION
### What I did

Updates release-drafter to v6.  Looke like probably due to Nodejs being deprecated on the platform?

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
