### PR TITLE
refactor: remove goerli

### DIFF
--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -25,8 +25,6 @@ def providers():
 
     yield "arbitrum", LOCAL_NETWORK_NAME, HardhatProvider
     yield "arbitrum", "mainnet-fork", HardhatForkProvider
-    # TODO: Remove when goerli is sunset
-    yield "arbitrum", "goerli-fork", HardhatForkProvider
     yield "arbitrum", "sepolia-fork", HardhatForkProvider
 
     yield "avalanche", LOCAL_NETWORK_NAME, HardhatProvider
@@ -43,8 +41,6 @@ def providers():
 
     yield "optimism", LOCAL_NETWORK_NAME, HardhatProvider
     yield "optimism", "mainnet-fork", HardhatForkProvider
-    # TODO: Remove when goerli is sunset
-    yield "optimism", "goerli-fork", HardhatForkProvider
     yield "optimism", "sepolia-fork", HardhatForkProvider
 
     yield "base", LOCAL_NETWORK_NAME, HardhatProvider

--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -50,6 +50,7 @@ def providers():
     yield "polygon", LOCAL_NETWORK_NAME, HardhatProvider
     yield "polygon", "mainnet-fork", HardhatForkProvider
     yield "polygon", "mumbai-fork", HardhatForkProvider
+    yield "polygon", "amoy-fork", HardhatForkProvider
 
     yield "gnosis", LOCAL_NETWORK_NAME, HardhatProvider
     yield "gnosis", "mainnet-fork", HardhatForkProvider

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -21,10 +21,6 @@ hardhat:
         upstream_provider: alchemy
         block_number: 17040366
         host: 127.0.0.1:7110
-      goerli:
-        upstream_provider: alchemy
-        block_number: 7849922
-        host: 127.0.0.1:7111
       sepolia:
         upstream_provider: alchemy
         block_number: 3091950

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import json
 import shutil
 import subprocess
-import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import mkdtemp
@@ -14,6 +13,7 @@ from _pytest.runner import pytest_runtest_makereport as orig_pytest_runtest_make
 from ape.contracts import ContractContainer
 from ape.exceptions import APINotImplementedError, UnknownSnapshotError
 from ape.managers.config import CONFIG_FILE_NAME
+from ape.utils import create_tempdir
 from ethpm_types import ContractType
 
 from ape_hardhat import HardhatProvider
@@ -227,9 +227,7 @@ def sepolia_fork_provider(name, networks, sepolia_fork_port):
 def temp_config(config):
     @contextmanager
     def func(data: Dict, package_json: Optional[Dict] = None):
-        with tempfile.TemporaryDirectory() as temp_dir_str:
-            temp_dir = Path(temp_dir_str)
-
+        with create_tempdir() as temp_dir:
             config._cached_configs = {}
             config_file = temp_dir / CONFIG_FILE_NAME
             config_file.touch()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ NAME = "hardhat"
 # Needed to test tracing support in core `ape test` command.
 pytest_plugins = ["pytester"]
 MAINNET_FORK_PORT = 9001
-GOERLI_FORK_PORT = 9002
+SEPOLIA_FORK_PORT = 9002
 
 
 def pytest_runtest_makereport(item, call):
@@ -211,14 +211,14 @@ def mainnet_fork_provider(name, networks, mainnet_fork_port):
 
 
 @pytest.fixture
-def goerli_fork_port():
-    return GOERLI_FORK_PORT
+def sepolia_fork_port():
+    return SEPOLIA_FORK_PORT
 
 
 @pytest.fixture
-def goerli_fork_provider(name, networks, goerli_fork_port):
-    with networks.ethereum.goerli_fork.use_provider(
-        name, provider_settings={"host": f"http://127.0.0.1:{goerli_fork_port}"}
+def sepolia_fork_provider(name, networks, sepolia_fork_port):
+    with networks.ethereum.sepolia_fork.use_provider(
+        name, provider_settings={"host": f"http://127.0.0.1:{sepolia_fork_port}"}
     ) as provider:
         yield provider
 

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -20,7 +20,7 @@ def mainnet_fork_contract_instance(owner, contract_container, mainnet_fork_provi
 
 @pytest.mark.fork
 def test_multiple_providers(
-    name, networks, connected_provider, mainnet_fork_port, goerli_fork_port
+    name, networks, connected_provider, mainnet_fork_port, sepolia_fork_port
 ):
     default_host = "http://127.0.0.1:8545"
     assert networks.active_provider.name == name
@@ -34,14 +34,14 @@ def test_multiple_providers(
         assert networks.active_provider.name == name
         assert networks.active_provider.network.name == "mainnet-fork"
         assert networks.active_provider.uri == mainnet_fork_host
-        goerli_fork_host = f"http://127.0.0.1:{goerli_fork_port}"
+        sepolia_fork_host = f"http://127.0.0.1:{sepolia_fork_port}"
 
-        with networks.ethereum.goerli_fork.use_provider(
-            name, provider_settings={"host": goerli_fork_host}
+        with networks.ethereum.sepolia_fork.use_provider(
+            name, provider_settings={"host": sepolia_fork_host}
         ):
             assert networks.active_provider.name == name
-            assert networks.active_provider.network.name == "goerli-fork"
-            assert networks.active_provider.uri == goerli_fork_host
+            assert networks.active_provider.network.name == "sepolia-fork"
+            assert networks.active_provider.uri == sepolia_fork_host
 
         assert networks.active_provider.name == name
         assert networks.active_provider.network.name == "mainnet-fork"
@@ -60,7 +60,7 @@ def test_fork_config(name, config, network):
 
 
 @pytest.mark.fork
-def test_goerli_impersonate(accounts, goerli_fork_provider):
+def test_sepolia_impersonate(accounts, sepolia_fork_provider):
     impersonated_account = accounts[TEST_ADDRESS]
     other_account = accounts[0]
     receipt = impersonated_account.transfer(other_account, "1 wei")
@@ -91,21 +91,21 @@ def test_request_timeout(networks, config, mainnet_fork_provider):
 
 
 @pytest.mark.fork
-def test_reset_fork_no_fork_block_number(networks, goerli_fork_provider):
-    goerli_fork_provider.mine(5)
-    prev_block_num = goerli_fork_provider.get_block("latest").number
-    goerli_fork_provider.reset_fork()
-    block_num_after_reset = goerli_fork_provider.get_block("latest").number
+def test_reset_fork_no_fork_block_number(networks, sepolia_fork_provider):
+    sepolia_fork_provider.mine(5)
+    prev_block_num = sepolia_fork_provider.get_block("latest").number
+    sepolia_fork_provider.reset_fork()
+    block_num_after_reset = sepolia_fork_provider.get_block("latest").number
     assert block_num_after_reset < prev_block_num
 
 
 @pytest.mark.fork
-def test_reset_fork_specify_block_number_via_argument(networks, goerli_fork_provider):
-    goerli_fork_provider.mine(5)
-    prev_block_num = goerli_fork_provider.get_block("latest").number
+def test_reset_fork_specify_block_number_via_argument(networks, sepolia_fork_provider):
+    sepolia_fork_provider.mine(5)
+    prev_block_num = sepolia_fork_provider.get_block("latest").number
     new_block_number = prev_block_num - 1
-    goerli_fork_provider.reset_fork(block_number=new_block_number)
-    block_num_after_reset = goerli_fork_provider.get_block("latest").number
+    sepolia_fork_provider.reset_fork(block_number=new_block_number)
+    block_num_after_reset = sepolia_fork_provider.get_block("latest").number
     assert block_num_after_reset == new_block_number
 
 
@@ -177,9 +177,9 @@ def test_get_receipt(mainnet_fork_provider, mainnet_fork_contract_instance, owne
         ("mainnet", 8994, False, 15_964_699, False),
         ("mainnet", 8995, False, 15_932_345, True),
         ("mainnet", 8996, True, 15_900_000, False),
-        ("goerli", 8997, False, 7_948_861, False),
-        ("goerli", 8998, False, 7_424_430, True),
-        ("goerli", 8999, True, 7_900_000, False),
+        ("sepolia", 8997, False, 7_948_861, False),
+        ("sepolia", 8998, False, 7_424_430, True),
+        ("sepolia", 8999, True, 7_900_000, False),
     ],
 )
 def test_hardhat_command(

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -1,10 +1,10 @@
-import tempfile
 from pathlib import Path
 
 import pytest
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractInstance
 from ape.exceptions import ContractLogicError
+from ape.utils import create_tempdir
 from ape_ethereum.ecosystem import NETWORKS
 
 from ape_hardhat.provider import HardhatForkProvider
@@ -84,8 +84,7 @@ def test_request_timeout(networks, config, mainnet_fork_provider):
     assert actual == expected
 
     # Test default behavior
-    with tempfile.TemporaryDirectory() as temp_dir_str:
-        temp_dir = Path(temp_dir_str)
+    with create_tempdir() as temp_dir:
         with config.using_project(temp_dir):
             assert networks.active_provider.timeout == 300
 

--- a/tests/test_fork_provider.py
+++ b/tests/test_fork_provider.py
@@ -52,7 +52,7 @@ def test_multiple_providers(
     assert networks.active_provider.uri == default_host
 
 
-@pytest.mark.parametrize("network", [k for k in NETWORKS.keys()])
+@pytest.mark.parametrize("network", [k for k in NETWORKS.keys() if k != "goerli"])
 def test_fork_config(name, config, network):
     plugin_config = config.get_config(name)
     network_config = plugin_config["fork"].get("ethereum", {}).get(network, {})

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,6 +1,4 @@
 import shutil
-import tempfile
-from pathlib import Path
 
 import pytest
 import requests
@@ -9,6 +7,7 @@ from ape.api.accounts import ImpersonatedAccount
 from ape.contracts import ContractContainer
 from ape.exceptions import ContractLogicError
 from ape.types import CallTreeNode, TraceFrame
+from ape.utils import create_tempdir
 from evm_trace import CallType
 from hexbytes import HexBytes
 
@@ -146,8 +145,7 @@ def test_request_timeout(connected_provider, config):
     assert actual == expected
 
     # Test default behavior
-    with tempfile.TemporaryDirectory() as temp_dir_str:
-        temp_dir = Path(temp_dir_str)
+    with create_tempdir() as temp_dir:
         with config.using_project(temp_dir):
             assert connected_provider.timeout == 30
 


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
