### PR TITLE
perf: plugin load time

### DIFF
--- a/ape_hardhat/__init__.py
+++ b/ape_hardhat/__init__.py
@@ -4,20 +4,22 @@ implementation written in Node.js).
 """
 
 from ape import plugins
-from ape.api.networks import LOCAL_NETWORK_NAME
-from ape_ethereum.ecosystem import NETWORKS
-
-from .exceptions import HardhatProviderError, HardhatSubprocessError
-from .provider import HardhatForkProvider, HardhatNetworkConfig, HardhatProvider
 
 
 @plugins.register(plugins.Config)
 def config_class():
+    from .provider import HardhatNetworkConfig
+
     return HardhatNetworkConfig
 
 
 @plugins.register(plugins.ProviderPlugin)
 def providers():
+    from ape.api.networks import LOCAL_NETWORK_NAME
+    from ape_ethereum.ecosystem import NETWORKS
+
+    from .provider import HardhatForkProvider, HardhatProvider
+
     yield "ethereum", LOCAL_NETWORK_NAME, HardhatProvider
 
     for network in NETWORKS:
@@ -55,6 +57,17 @@ def providers():
     yield "gnosis", LOCAL_NETWORK_NAME, HardhatProvider
     yield "gnosis", "mainnet-fork", HardhatForkProvider
     yield "gnosis", "chaido-fork", HardhatForkProvider
+
+
+def __getattr__(name: str):
+    if name.endswith("Error"):
+        import ape_hardhat.exceptions as err_module
+
+        return getattr(err_module, name)
+
+    import ape_hardhat.provider as module
+
+    return getattr(module, name)
 
 
 __all__ = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,8 @@ exclude =
 	docs
 	build
 	node_modules
-ignore = E704,W503,PYD002
+ignore = E704,W503,PYD002,TC003,TC006
 per-file-ignores =
     # The traces have to be formatted this way for the tests.
     tests/expected_traces.py: E501
+type-checking-pydantic-enabled = True


### PR DESCRIPTION
### What I did

Before:

```
In [1]: %time import ape_hardhat
CPU times: user 1.17 s, sys: 152 ms, total: 1.33 s
Wall time: 1.36 s
```

After:

```
oIn [1]: %time import ape_hardhat
CPU times: user 8.23 ms, sys: 3.43 ms, total: 11.7 ms
Wall time: 11.5 ms
```

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
